### PR TITLE
Add 'KnownRepr', a class for generating singleton type values

### DIFF
--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -40,6 +40,8 @@ module Data.Parameterized.Classes
   , ShowF(..)
   , HashableF(..)
   , CoercibleF(..)
+    -- * KnownRepr
+  , KnownRepr(..)
     -- * Re-exports
   , Data.Maybe.isJust
   ) where
@@ -169,3 +171,10 @@ class HashableF (f :: k -> *) where
   -- | Hash with default salt.
   hashF :: f tp -> Int
   hashF = hashWithSaltF defaultSalt
+
+-- | This class is parameterized by a kind @k@ (typically a data
+-- kind), a type constructor @f@ of kind @k -> *@ (typically a GADT of
+-- singleton types indexed by @k@), and an index parameter @ctx@ of
+-- kind @k@.
+class KnownRepr (f :: k -> *) (ctx :: k) where
+  knownRepr :: f ctx

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -27,6 +27,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -529,6 +530,15 @@ traverseWithIndex :: Applicative m
                   -> m (Assignment g ctx)
 traverseWithIndex f a = generateM (size a) $ \i -> f i (a ! i)
 
+------------------------------------------------------------------------
+-- KnownRepr instances
+
+instance (KnownRepr (Assignment f) ctx, KnownRepr f bt)
+      => KnownRepr (Assignment f) (ctx ::> bt) where
+  knownRepr = knownRepr %> knownRepr
+
+instance KnownRepr (Assignment f) EmptyCtx where
+  knownRepr = empty
 
 --------------------------------------------------------------------------------------
 -- lookups and update for lenses

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -908,6 +908,16 @@ appendBin x (PlusZero _ y) = x `appendBin` y
 x ++ Assignment y = x `appendBin` y
 
 ------------------------------------------------------------------------
+-- KnownRepr instances
+
+instance (KnownRepr (Assignment f) ctx, KnownRepr f bt)
+      => KnownRepr (Assignment f) (ctx ::> bt) where
+  knownRepr = knownRepr %> knownRepr
+
+instance KnownRepr (Assignment f) EmptyCtx where
+  knownRepr = empty
+
+------------------------------------------------------------------------
 -- Lens combinators
 
 unsafeLens :: Int -> Lens.Lens (Assignment f ctx) (Assignment f ctx') (f tp) (f u)

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -170,11 +170,11 @@ instance HashableF NatRepr where
   hashWithSaltF = hashWithSalt
 
 -- | This generates a NatRepr from a type-level context.
-knownNat :: KnownNat n => NatRepr n
-knownNat = go Proxy
-  where go :: KnownNat n => Proxy n -> NatRepr n
-        go p = assert (v <= maxInt) (NatRepr (fromInteger v))
-          where v = natVal p
+knownNat :: forall n . KnownNat n => NatRepr n
+knownNat = NatRepr (natVal (Proxy :: Proxy n))
+
+instance (KnownNat n) => KnownRepr NatRepr n where
+  knownRepr = knownNat
 
 data IsZeroNat n where
   ZeroNat    :: IsZeroNat 0

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -16,6 +16,7 @@ contained in a NatRepr value matches its static type.
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
@@ -97,7 +98,6 @@ module Data.Parameterized.NatRepr
   , Data.Parameterized.Some.Some
   ) where
 
-import Control.Exception (assert)
 import Data.Bits ((.&.))
 import Data.Hashable
 import Data.Proxy as Proxy

--- a/src/Data/Parameterized/SymbolRepr.hs
+++ b/src/Data/Parameterized/SymbolRepr.hs
@@ -14,6 +14,7 @@ correspondingly has very few functions that manipulate them.
 -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
@@ -72,6 +73,9 @@ knownSymbol = go Proxy
            | Text.unpack txt == str = txt
            | otherwise = error $ "Unrepresentable symbol! "++ str
          where txt = Text.pack str
+
+instance (GHC.KnownSymbol s) => KnownRepr SymbolRepr s where
+  knownRepr = knownSymbol
 
 instance TestEquality SymbolRepr where
    testEquality (SymbolRepr x :: SymbolRepr x) (SymbolRepr y)


### PR DESCRIPTION
This is directly pulled out of 'Lang.Crucible.BaseTypes', but it's useful in situations outside of Crucible, too.