### PR TITLE
Add precedence support to ShowF

### DIFF
--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -39,6 +39,7 @@ module Data.Parameterized.Classes
   , fromOrdering
     -- * Typeclass generalizations
   , ShowF(..)
+  , showsF
   , HashableF(..)
   , CoercibleF(..)
     -- * Optics generalizations
@@ -211,8 +212,13 @@ class ShowF (f :: k -> *) where
   showF :: forall tp . f tp -> String
   showF x = withShow (Proxy :: Proxy f) (Proxy :: Proxy tp) (show x)
 
-  showsF :: forall tp . f tp -> String -> String
-  showsF x = withShow (Proxy :: Proxy f) (Proxy :: Proxy tp) (shows x)
+  -- | Like 'showsPrec', the precedence argument is /one more/ than the
+  -- precedence of the enclosing context.
+  showsPrecF :: forall tp. Int -> f tp -> String -> String
+  showsPrecF p x = withShow (Proxy :: Proxy f) (Proxy :: Proxy tp) (showsPrec p x)
+
+showsF :: ShowF f => f tp -> String -> String
+showsF x = showsPrecF 0 x
 
 instance Show x => ShowF (Const x)
 

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -53,7 +53,9 @@ infixr 5 :<
 instance ShowF f => Show (List f sh) where
   showsPrec _ Nil = showString "Nil"
   showsPrec p (elt :< rest) = showParen (p > precCons) $
-    showsPrecF (precCons+1) elt . showString " :< " . showsPrec (precCons+1) rest
+    -- Unlike a derived 'Show' instance, we don't print parens implied
+    -- by right associativity.
+    showsPrecF (precCons+1) elt . showString " :< " . showsPrec 0 rest
     where
       precCons = 5
 

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -51,8 +51,11 @@ data List :: (k -> *) -> [k] -> * where
 infixr 5 :<
 
 instance ShowF f => Show (List f sh) where
-  show Nil = "Nil"
-  show (elt :< rest) = showF elt ++ " :< " ++ show rest
+  showsPrec _ Nil = showString "Nil"
+  showsPrec p (elt :< rest) = showParen (p > precCons) $
+    showsPrecF (precCons+1) elt . showString " :< " . showsPrec (precCons+1) rest
+    where
+      precCons = 5
 
 instance ShowF f => ShowF (List f)
 


### PR DESCRIPTION
By adding `showsPrecF`, analogous to `showsPrec` in `Show`.

Also, update the `Show` manual instance for `Data.Parameterized.List`
to insert parens when neded, by using `showsPrec` and `showsPrecF`
instead of `show`. E.g. in Brittle

    SynthInstruction RealOpcode AddRr R32 Reg1 :< R32 Reg3 :< Nil

becomes

    SynthInstruction (RealOpcode AddRr) (R32 Reg1 :< (R32 Reg3 :< Nil))

after using `showsPrecF` in place of `showF` in the manual `Show`
instance for `SynthInstruction`.