### PR TITLE
 Port Vector module from Crucible.Lang 

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -87,6 +87,7 @@ test-suite parameterizedTests
   other-modules:
     Test.Context
     Test.NatRepr
+    Test.Vector
 
   build-depends:
     base,

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -31,7 +31,7 @@ contained in a NatRepr value matches its static type.
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 #endif
 module Data.Parameterized.NatRepr
-  ( NatRepr(NatRepr)
+  ( NatRepr
   , natValue
   , knownNat
   , withKnownNat

--- a/test/Test/Vector.hs
+++ b/test/Test/Vector.hs
@@ -1,0 +1,28 @@
+{-# Language DataKinds #-}
+{-# Language FlexibleInstances #-}
+{-# Language StandaloneDeriving #-}
+
+module Test.Vector
+( vecTests
+) where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import Data.Parameterized.NatRepr
+import Data.Parameterized.Vector
+import GHC.TypeLits
+import Prelude hiding (reverse)
+
+instance KnownNat n => Arbitrary (NatRepr n) where
+  arbitrary = return knownNat
+
+vecTests :: IO TestTree
+vecTests = testGroup "Vector" <$> return
+  [ testProperty "reverse100" $
+      \n v -> fromList (n :: NatRepr 100) (v :: [Int]) ==
+              (reverse <$> (reverse <$> (fromList n v)))
+  , testProperty "reverseSingleton" $
+      \n v -> fromList (n :: NatRepr 1) (v :: [Int]) ==
+              (reverse <$> (fromList n v))
+  ]

--- a/test/UnitTest.hs
+++ b/test/UnitTest.hs
@@ -4,6 +4,7 @@ import Test.Tasty.Runners.AntXML
 
 import qualified Test.Context
 import qualified Test.NatRepr
+import qualified Test.Vector
 
 main :: IO ()
 main = tests >>= defaultMainWithIngredients ingrs
@@ -19,4 +20,5 @@ tests :: IO TestTree
 tests = testGroup "ParameterizedUtils" <$> sequence
   [ Test.Context.contextTests
   , Test.NatRepr.natTests
+  , Test.Vector.vecTests
   ]


### PR DESCRIPTION
- Also port What4.Utils.Endian
- At the suggestion of @robdockins
- All functions mentioning Crucible types have been removed
- This is a prelude to implementing LLVM's bswap intrinsic for Crucible
- Also add Travis CI configuration (build here: https://travis-ci.org/siddharthist/parameterized-utils/jobs/419784177)