### PR TITLE
Construction and monadic splitting of vectors

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -1,5 +1,5 @@
 Name:          parameterized-utils
-Version:       1.0.3
+Version:       1.0.4
 Author:        Galois Inc.
 Maintainer:    jhendrix@galois.com
 Build-type:    Simple

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -54,6 +54,7 @@ library
     Data.Parameterized.Context.Unsafe
     Data.Parameterized.Ctx
     Data.Parameterized.Ctx.Proofs
+    Data.Parameterized.DecidableEq
     Data.Parameterized.HashTable
     Data.Parameterized.List
     Data.Parameterized.Map

--- a/src/Data/Parameterized/DecidableEq.hs
+++ b/src/Data/Parameterized/DecidableEq.hs
@@ -1,0 +1,37 @@
+{-|
+Copyright        : (c) Galois, Inc 2014-2018
+Maintainer       : Langston Barrett <langston@galois.com>
+
+This defines a class @DecidableEq@, which represents decidable equality on a
+type family.
+
+This is different from GHC's @TestEquality@ in that it provides evidence
+of non-equality. In fact, it is a superclass of @TestEquality@.
+-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
+module Data.Parameterized.DecidableEq
+  ( DecidableEq(..)
+  ) where
+
+import Data.Void (Void)
+import Data.Type.Equality ((:~:))
+
+-- | Decidable equality.
+class DecidableEq f where
+  decEq :: f a -> f b -> Either (a :~: b) ((a :~: b) -> Void)
+
+-- TODO: instances for sums, products of types with decidable equality
+
+-- import Data.Type.Equality ((:~:), TestEquality(..))
+-- instance (DecidableEq f) => TestEquality f where
+--   testEquality a b =
+--     case decEq a b of
+--       Left  prf -> Just prf
+--       Right _   -> Nothing

--- a/src/Data/Parameterized/Vector.hs
+++ b/src/Data/Parameterized/Vector.hs
@@ -45,6 +45,7 @@ module Data.Parameterized.Vector
     -- * Construction
   , singleton
   , cons
+  , snoc
   , generate
   , generateM
 
@@ -317,7 +318,6 @@ cons a v@(Vector x) = case leqLen v of LeqProof -> (Vector (Vector.cons a x))
 -- | Add an element to the tail of a vector
 snoc :: forall n a. Vector n a -> a -> Vector (n+1) a
 snoc v@(Vector x) a = case leqLen v of LeqProof -> (Vector (Vector.snoc x a))
-
 
 -- | This newtype wraps Vector so that we can curry it in the call to
 -- @natRecBounded@. It adds 1 to the length so that the base case is

--- a/test/Test/Vector.hs
+++ b/test/Test/Vector.hs
@@ -24,12 +24,18 @@ instance KnownNat n => Arbitrary (NatRepr n) where
 -- GHC thinks that this instances overlaps with the
 -- "Arbitrary a => Arbitrary (Maybe a)" instance from QuickCheck, but it doesn't:
 -- there is no "Arbitrary a => Arbitrary (Vector n a)".
+--
+-- While it might seem like this would just successfully generate a lot
+-- of "Nothing", it does a pretty good job. Just try changing one of the tests!
 instance {-# OVERLAPS #-} forall a n. (1 <= n, Arbitrary a, KnownNat n)
     => Arbitrary (Maybe (Vector n a)) where
   arbitrary = do
     n <- (arbitrary :: Gen (NatRepr n))
     l <- (arbitrary :: Gen [a])
     return $ fromList n l
+
+instance Show (Int -> Ordering) where
+  show _ = "unshowable"
 
 -- We use @Ordering@ just because it's simple
 vecTests :: IO TestTree
@@ -43,4 +49,16 @@ vecTests = testGroup "Vector" <$> return
   , testProperty "split-join" $
       \n w v -> (v :: Maybe (Vector (5 * 5) Ordering)) ==
                 (join (n :: NatRepr 5) . split n (w :: NatRepr 5) <$> v)
+  -- @cons@ is the same for vectors or lists
+  , testProperty "cons" $
+      \n v x -> (cons x <$> fromList (n :: NatRepr 20) (v :: [Ordering])) ==
+                (fromList (incNat n) (x:v))
+  -- @snoc@ is like appending to a list
+  , testProperty "snoc" $
+      \n v x -> (flip snoc x <$> fromList (n :: NatRepr 20) (v :: [Ordering])) ==
+                (fromList (incNat n) (v ++ [x]))
+  -- @generate@ is like mapping a function over indices
+  , testProperty "generate" $
+      \n f -> Just (generate (n :: NatRepr 55) ((f :: Int -> Ordering) . widthVal)) ==
+              (fromList (incNat n) (map f [0..widthVal n]) :: Maybe (Vector 56 Ordering))
   ]


### PR DESCRIPTION
I implemented several things that I didn't end up needing.

In this PR:
- `NatRepr`:
  + Variants of `natRec`
  + Facts about `<`
  + Decidable relations: `=` and `<=`
 - `Vector`:
  + Functions for creating vectors: `cons`, `snoc`, `generate`, `generateM`
  + `splitWithM`
