### PR TITLE
Update for GHC 8.6.1

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -14,7 +14,7 @@ Description:
   intended for things like expression libraries where one wishes
   to leverage the Haskell type-checker to improve type-safety by encoding
   the object language type system into data kinds.
-tested-with: GHC==8.4.3
+tested-with: GHC==8.4.3, GHC==8.6.1
 
 -- Many (but not all, sadly) uses of unsafe operations are
 -- controlled by this compile flag.  When this flag is set
@@ -31,7 +31,7 @@ source-repository head
 
 library
   build-depends:
-    base >= 4.7 && < 4.12,
+    base >= 4.7 && < 4.13,
     th-abstraction >=0.1 && <0.3,
     containers,
     deepseq,

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -34,6 +34,9 @@ contained in a NatRepr value matches its static type.
 #if MIN_VERSION_base(4,9,0)
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE NoStarIsType #-}
+#endif
 module Data.Parameterized.NatRepr
   ( NatRepr
   , natValue

--- a/src/Data/Parameterized/Nonce.hs
+++ b/src/Data/Parameterized/Nonce.hs
@@ -53,7 +53,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import Data.Parameterized.Classes
 import Data.Parameterized.Some
 
-#if MIN_VERSION_base(4,9,0)
+#if MIN_VERSION_base(4,9,0) && __GLASGOW_HASKELL__ < 805
 import Data.Kind
 #endif
 

--- a/src/Data/Parameterized/Vector.hs
+++ b/src/Data/Parameterized/Vector.hs
@@ -2,6 +2,10 @@
 {-# Language PatternGuards #-}
 {-# Language TypeApplications, ScopedTypeVariables #-}
 {-# Language Rank2Types, RoleAnnotations #-}
+{-# Language CPP #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# Language NoStarIsType #-}
+#endif
 -- | A vector fixed-size vector of typed elements.
 module Data.Parameterized.Vector
   ( Vector

--- a/test/Test/Vector.hs
+++ b/test/Test/Vector.hs
@@ -5,7 +5,10 @@
 {-# Language FlexibleInstances #-}
 {-# Language ScopedTypeVariables #-}
 {-# Language StandaloneDeriving #-}
-
+{-# Language CPP #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# Language NoStarIsType #-}
+#endif
 module Test.Vector
 ( vecTests
 ) where


### PR DESCRIPTION
This commit should get everything ready for GHC 8.6.1.

There are warnings when building the testsuite, but this seems unchanged from building on 8.4.3, so I did not try to fix.