### PR TITLE
New modules: ClassesC and Compose

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -1,5 +1,5 @@
 Name:          parameterized-utils
-Version:       1.0.7
+Version:       1.0.8
 Author:        Galois Inc.
 Maintainer:    jhendrix@galois.com
 Build-type:    Simple
@@ -49,6 +49,8 @@ library
   exposed-modules:
     Data.Parameterized
     Data.Parameterized.Classes
+    Data.Parameterized.ClassesC
+    Data.Parameterized.Compose
     Data.Parameterized.Context
     Data.Parameterized.Context.Safe
     Data.Parameterized.Context.Unsafe
@@ -62,15 +64,15 @@ library
     Data.Parameterized.Nonce
     Data.Parameterized.Nonce.Transformers
     Data.Parameterized.Nonce.Unsafe
+    Data.Parameterized.Pair
     Data.Parameterized.Some
     Data.Parameterized.SymbolRepr
-    Data.Parameterized.Pair
     Data.Parameterized.TH.GADT
     Data.Parameterized.TraversableF
     Data.Parameterized.TraversableFC
-    Data.Parameterized.Vector
     Data.Parameterized.Utils.BinTree
     Data.Parameterized.Utils.Endian
+    Data.Parameterized.Vector
 
   ghc-options: -Wall
 

--- a/src/Data/Parameterized/Compose.hs
+++ b/src/Data/Parameterized/Compose.hs
@@ -1,0 +1,45 @@
+{-|
+Copyright        : (c) Galois, Inc 2014-2018
+Maintainer       : Langston Barrett <langston@galois.com
+
+Utilities for working with "Data.Functor.Compose".
+
+NB: This module contains an orphan instance. It will be included in GHC 8.10,
+see https://gitlab.haskell.org/ghc/ghc/merge_requests/273.
+-}
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
+
+module Data.Parameterized.Compose
+  ( testEqualityComposeBare
+  ) where
+
+import Data.Functor.Compose
+import Data.Type.Equality
+
+-- | The deduction (via generativity) that if @g x :~: g y@ then @x :~: y@.
+--
+-- See https://gitlab.haskell.org/ghc/ghc/merge_requests/273.
+testEqualityComposeBare :: forall (f :: k -> *) (g :: l -> k) x y.
+                           (forall w z. f w -> f z -> Maybe (w :~: z))
+                        -> Compose f g x
+                        -> Compose f g y
+                        -> Maybe (x :~: y)
+testEqualityComposeBare testEquality_ (Compose x) (Compose y) =
+  case (testEquality_ x y :: Maybe (g x :~: g y)) of
+    Just Refl -> Just (Refl :: x :~: y)
+    Nothing   -> Nothing
+
+testEqualityCompose :: forall (f :: k -> *) (g :: l -> k) x y. (TestEquality f)
+                    => Compose f g x
+                    -> Compose f g y
+                    -> Maybe (x :~: y)
+testEqualityCompose = testEqualityComposeBare testEquality
+
+instance (TestEquality f) => TestEquality (Compose f g) where
+  testEquality = testEqualityCompose


### PR DESCRIPTION
All of this is helpful in my current task of adding a new type family to Crucible with kind `:: (BaseType -> Type) -> Type`.