### PR TITLE
WithRepr & Safe Peano

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -23,7 +23,7 @@ tested-with: GHC==8.4.3, GHC==8.6.1
 -- impose a significant performance hit.
 flag unsafe-operations
   Description: Use unsafe operations to improve performance
-  Default: True
+  Default: False
 
 source-repository head
   type: git
@@ -75,6 +75,7 @@ library
     Data.Parameterized.Utils.BinTree
     Data.Parameterized.Utils.Endian
     Data.Parameterized.Vector
+    Data.Parameterized.WithRepr                  
 
   ghc-options: -Wall
 

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -23,7 +23,7 @@ tested-with: GHC==8.4.3, GHC==8.6.1
 -- impose a significant performance hit.
 flag unsafe-operations
   Description: Use unsafe operations to improve performance
-  Default: False
+  Default: True
 
 source-repository head
   type: git

--- a/src/Data/Parameterized/Peano.hs
+++ b/src/Data/Parameterized/Peano.hs
@@ -187,7 +187,7 @@ instance Eq (PeanoRepr m) where
   _ == _ = True
 
 instance TestEquality PeanoRepr where
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
   testEquality (PeanoRepr m) (PeanoRepr n)
     | m == n = Just (unsafeCoerce Refl)
     | otherwise = Nothing
@@ -201,7 +201,7 @@ instance TestEquality PeanoRepr where
 #endif
 
 instance DecidableEq PeanoRepr where
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
   decEq (PeanoRepr m) (PeanoRepr n)
     | m == n    = Left $ unsafeCoerce Refl
     | otherwise = Right $
@@ -220,7 +220,7 @@ instance DecidableEq PeanoRepr where
 #endif
 
 instance OrdF PeanoRepr where
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
   compareF (PeanoRepr m) (PeanoRepr n)
     | m < n     = unsafeCoerce LTF
     | m == n    = unsafeCoerce EQF
@@ -337,7 +337,7 @@ repeatP n f s = case peanoView n of
 
 -- | Convert a Word64 to a PeanoRepr
 mkPeanoRepr :: Word64 -> Some PeanoRepr
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
 mkPeanoRepr n = Some (PeanoRepr n)
 #else
 mkPeanoRepr 0 = Some ZRepr

--- a/src/Data/Parameterized/Peano.hs
+++ b/src/Data/Parameterized/Peano.hs
@@ -15,6 +15,7 @@ natural numbers is an Int.
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Data/Parameterized/WithRepr.hs
+++ b/src/Data/Parameterized/WithRepr.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-|
+Copyright        : (c) Galois, Inc 2019
+
+This module declares a class with a single method that can be used to
+derive a 'KnownRepr' constraint from an explicit 'Repr' argument.
+Clients of this method need only create an empty instance. The default
+implementation suffices.
+
+For example, suppose we have defined a 'Repr' type for 'Peano' numbers:
+
+@
+data Peano = Z | S Peano
+
+data PeanoRepr p where
+    ZRepr :: PeanoRepr Z
+    SRepr :: PeanoRepr p -> PeanoRepr (S p)
+
+-- KnownRepr instances
+@
+
+Then the instance for this class
+@
+instance IsRepr PRepr
+@
+
+means that functions with 'KnownRepr' constraints can be used after
+pattern matching.
+
+@
+f :: KnownRepr PeanoRepr a => ...
+
+example :: PeanoRepr n -> ...
+example ZRepr = ...
+example (SRepr (pm::PeanoRepr m)) = ... withRepr pm f ...
+@
+
+
+NOTE: The type 'f' must be a *singleton* type--- i.e.  for a given
+type 'a' there should be only one value that inhabits 'f a'. If that
+is not the case, this operation can be used to subvert coherence.
+
+Credit: the unsafe implementation of 'withRepr' is taken from the
+'withSingI' function in the singletons library
+<http://hackage.haskell.org/package/singletons-2.5.1/>.  Packaging
+this method in a class here makes it more flexible---we do not have to
+define a dedicated 'Sing' type, but can use any convenient singleton
+as a 'Repr'.
+
+NOTE: if this module is compiled without UNSAFE_OPS, the default
+method will not be available.
+
+-}
+module Data.Parameterized.WithRepr(IsRepr(..)) where
+
+import Data.Parameterized.Classes
+
+#if UNSAFE_OPS
+import Data.Constraint(Dict(..))
+import Unsafe.Coerce(unsafeCoerce)
+
+import Data.Parameterized.NatRepr (NatRepr)
+import Data.Parameterized.SymbolRepr (SymbolRepr)
+import Data.Parameterized.Peano (PeanoRepr)
+import Data.Parameterized.Context(Assignment)
+import Data.Parameterized.List(List)
+#else
+import Data.Parameterized.Peano (PeanoRepr,PeanoView(..))
+#endif
+-- | Turn an explicit Repr value into an implict KnownRepr constraint
+class IsRepr (f :: k -> *) where
+
+  withRepr :: f a -> (KnownRepr f a => r) -> r
+
+#if UNSAFE_OPS
+  withRepr si r = case reprInstance si of
+                     Dict -> r
+
+reprInstance :: forall f a . IsRepr f => f a -> Dict (KnownRepr f a)
+reprInstance s = with_repr Dict
+   where
+     with_repr :: (KnownRepr f a => Dict (KnownRepr f a)) -> Dict (KnownRepr f a)
+     with_repr si = unsafeCoerce (Don'tInstantiate si) s
+
+newtype DI f a = Don'tInstantiate (KnownRepr f a => Dict (KnownRepr f a))
+#endif
+
+
+------------------------------------
+-- Instances for types defined in parameterized-utils
+
+#if UNSAFE_OPS
+instance IsRepr NatRepr
+instance IsRepr SymbolRepr
+instance IsRepr PeanoRepr
+instance IsRepr f => IsRepr (List f)
+instance IsRepr f => IsRepr (Assignment f)
+#else
+-- awful, slow implementation for PeanoRepr
+instance IsRepr PeanoRepr where
+  withRepr ZRepr f     = f
+  withRepr (SRepr m) f = withRepr m f
+#endif

--- a/src/Data/Parameterized/WithRepr.hs
+++ b/src/Data/Parameterized/WithRepr.hs
@@ -26,7 +26,7 @@ data PeanoRepr p where
 
 Then the instance for this class
 @
-instance IsRepr PRepr
+instance IsRepr PeanoRepr
 @
 
 means that functions with 'KnownRepr' constraints can be used after
@@ -60,7 +60,7 @@ module Data.Parameterized.WithRepr(IsRepr(..)) where
 
 import Data.Parameterized.Classes
 
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
 import Data.Constraint(Dict(..))
 import Unsafe.Coerce(unsafeCoerce)
 
@@ -77,7 +77,7 @@ class IsRepr (f :: k -> *) where
 
   withRepr :: f a -> (KnownRepr f a => r) -> r
 
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
   withRepr si r = case reprInstance si of
                      Dict -> r
 
@@ -94,7 +94,7 @@ newtype DI f a = Don'tInstantiate (KnownRepr f a => Dict (KnownRepr f a))
 ------------------------------------
 -- Instances for types defined in parameterized-utils
 
-#if UNSAFE_OPS
+#ifdef UNSAFE_OPS
 instance IsRepr NatRepr
 instance IsRepr SymbolRepr
 instance IsRepr PeanoRepr


### PR DESCRIPTION
This PR makes two changes:
  - Adds CPP to the Peano module so that it can be compiled without using unsafeCoerce 
    (not recommended)
  - Adds a new "WithRepr" class that generalizes "withPeanoRepr" and "withKnownNat" 
    (and provides additional instances for Symbol, Assignment and List).