### PR TITLE
for functions for TraversableF[C]

### DIFF
--- a/src/Data/Parameterized/TraversableF.hs
+++ b/src/Data/Parameterized/TraversableF.hs
@@ -20,7 +20,8 @@ module Data.Parameterized.TraversableF
   , foldrMF
   , TraversableF(..)
   , traverseF_
-  , forMFC_
+  , forF_
+  , forF
   , fmapFDefault
   , foldMapFDefault
   , allF
@@ -123,6 +124,11 @@ class (FunctorF t, FoldableF t) => TraversableF t where
 instance TraversableF (Const x) where
   traverseF _ (Const x) = pure (Const x)
 
+-- | Flipped 'traverseF'
+forF :: (TraversableF t, Applicative m) => t e -> (forall s . e s -> m (f s)) -> m (t f)
+forF f x = traverseF x f
+{-# INLINE forF #-}
+
 -- | This function may be used as a value for `fmapF` in a `FunctorF`
 -- instance.
 fmapFDefault :: TraversableF t => (forall s . e s -> f s) -> t e -> t f
@@ -142,9 +148,9 @@ traverseF_ f = foldrF (\e r -> f e *> r) (pure ())
 
 -- | Map each element of a structure to an action, evaluate
 -- these actions from left to right, and ignore the results.
-forMF_ :: (FoldableF t, Applicative m) => t f -> (forall x. f x -> m a) -> m ()
-forMF_ v f = traverseF_ f v
-{-# INLINE forMF_ #-}
+forF_ :: (FoldableF t, Applicative m) => t f -> (forall x. f x -> m a) -> m ()
+forF_ v f = traverseF_ f v
+{-# INLINE forF_ #-}
 
 ------------------------------------------------------------------------
 -- TraversableF (Compose s t)

--- a/src/Data/Parameterized/TraversableFC.hs
+++ b/src/Data/Parameterized/TraversableFC.hs
@@ -24,6 +24,8 @@ module Data.Parameterized.TraversableFC
   , TraversableFC(..)
   , traverseFC_
   , forMFC_
+  , forFC_
+  , forFC
   , fmapFCDefault
   , foldMapFCDefault
   , allFC
@@ -173,3 +175,17 @@ traverseFC_ f = foldrFC (\e r -> f e *> r) (pure ())
 forMFC_ :: (FoldableFC t, Applicative m) => t f c -> (forall x. f x -> m a) -> m ()
 forMFC_ v f = traverseFC_ f v
 {-# INLINE forMFC_ #-}
+{-# DEPRECATED forMFC_ "Use forFC_" #-}
+
+-- | Map each element of a structure to an action, evaluate
+-- these actions from left to right, and ignore the results.
+forFC_ :: (FoldableFC t, Applicative m) => t f c -> (forall x. f x -> m a) -> m ()
+forFC_ v f = traverseFC_ f v
+{-# INLINE forFC_ #-}
+
+-- | Flipped 'traverseFC'
+forFC ::
+  (TraversableFC t, Applicative m) =>
+  t f x -> (forall y. f y -> m (g y)) -> m (t g x)
+forFC v f = traverseFC f v
+{-# INLINE forFC #-}


### PR DESCRIPTION
It's customary to have for as a flipped traverse. This adds the
functions to TraversableF and TraversableFC. It also exposes
forF_ which was previously named forMF_ but wasn't actually
exported. I've updated the name to match current practices
while exporting it.

I've deprecated the older forMFC_ name as the forM name
typically indicates a legacy Monad constraint.