### PR TITLE
Fix precedences in structuralShowsPrec

### DIFF
--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -442,10 +442,10 @@ showCon :: ExpQ -> Name -> Int -> MatchQ
 showCon p nm n = do
   vars <- newNames "x" n
   let pat = ConP nm (VarP <$> vars)
-  let go s e = [| $(s) . showChar ' ' . showsPrec 10 $(varE e) |]
+  let go s e = [| $(s) . showChar ' ' . showsPrec 11 $(varE e) |]
   let ctor = [| showString $(return (LitE (StringL (nameBase nm)))) |]
   let rhs | null vars = ctor
-          | otherwise = [| showParen ($(p) >= 10) $(foldl go ctor vars) |]
+          | otherwise = [| showParen ($(p) >= 11) $(foldl go ctor vars) |]
   match (pure pat) (normalB rhs) []
 
 matchShowCtor :: ExpQ -> ConstructorInfo -> MatchQ


### PR DESCRIPTION
Function application test happens at 11 and not 10 in GHC derived Show instances, this change makes parameterized-utils compatible with derived instances.