### PR TITLE
New module: All

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -53,6 +53,7 @@ library
 
   exposed-modules:
     Data.Parameterized
+    Data.Parameterized.All
     Data.Parameterized.BoolRepr
     Data.Parameterized.Classes
     Data.Parameterized.ClassesC

--- a/src/Data/Parameterized/All.hs
+++ b/src/Data/Parameterized/All.hs
@@ -7,11 +7,33 @@
 --
 -- This module provides 'All', a GADT that encodes universal
 -- quantification/parametricity over a type variable.
+--
+-- The following is an example of a situation in which it might be necessary
+-- to use 'All' (though it is a bit contrived):
+--
+-- @
+--   {-# LANGUAGE FlexibleInstances #-}
+--   {-# LANGUAGE GADTs #-}
+--
+--   data F (x :: Bool) where
+--     FTrue :: F 'True
+--     FFalse :: F 'False
+--     FIndeterminate :: F b
+--
+--   data Value =
+--     VAllF (All F)
+--
+--   class Valuable a where
+--     valuation :: a -> Value
+--
+--   instance Valuable (All F) where
+--     valuation = VAllF
+--
+--   val1 :: Value
+--   val1 = valuation (All FIndeterminate)
+-- @
 ------------------------------------------------------------------------
 
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 

--- a/src/Data/Parameterized/All.hs
+++ b/src/Data/Parameterized/All.hs
@@ -1,14 +1,17 @@
 ------------------------------------------------------------------------
 -- |
 -- Module           : Data.Parameterized.All
--- Copyright        : (c) Galois, Inc 2014-2019
+-- Copyright        : (c) Galois, Inc 2019
 -- Maintainer       : Langston Barrett <langston@galois.com>
 -- Description      : Universal quantification, in a datatype
 --
 -- This module provides 'All', a GADT that encodes universal
--- quantification/parametricity over a type variable
+-- quantification/parametricity over a type variable.
 ------------------------------------------------------------------------
 
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -25,7 +28,7 @@ import Data.Parameterized.TraversableF
 newtype All (f :: k -> *) = All { getAll :: forall x. f x }
 
 instance FunctorF All where
-  fmapF nat (All a) = All (nat a)
+  fmapF f (All a) = All (f a)
 
 instance FoldableF All where
   foldMapF toMonoid (All x) = toMonoid x

--- a/src/Data/Parameterized/All.hs
+++ b/src/Data/Parameterized/All.hs
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Data.Parameterized.All
+-- Copyright        : (c) Galois, Inc 2014-2019
+-- Maintainer       : Langston Barrett <langston@galois.com>
+-- Description      : Universal quantification, in a datatype
+--
+-- This module provides 'All', a GADT that encodes universal
+-- quantification/parametricity over a type variable
+------------------------------------------------------------------------
+
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Data.Parameterized.All
+  ( All(..)
+  , allConst
+  ) where
+
+import Data.Functor.Const (Const(..))
+
+import Data.Parameterized.Classes
+import Data.Parameterized.TraversableF
+
+newtype All (f :: k -> *) = All { getAll :: forall x. f x }
+
+instance FunctorF All where
+  fmapF nat (All a) = All (nat a)
+
+instance FoldableF All where
+  foldMapF toMonoid (All x) = toMonoid x
+
+instance ShowF f => Show (All f) where
+  show (All fa) = showF fa
+
+instance EqF f => Eq (All f) where
+  (All x) == (All y) = eqF x y
+
+allConst :: a -> All (Const a)
+allConst a = All (Const a)


### PR DESCRIPTION
This is useful e.g. when defining instances for only polymorphic instances of an indexed datatype. 

For a concrete example of how I'd use this in SAW, I'd like to add `IsValue`/`FromValue` instances to `Any CrucibleSetupValue`, i.e. only those `SetupValue`s that are polymorphic in the LLVM architecture. 