### PR TITLE
Update parameterized-utils.cabal

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -36,18 +36,18 @@ source-repository head
 
 library
   build-depends: base >= 4.10 && < 5
-               , th-abstraction >=0.3 && <0.4
-               , constraints == 0.10.*
+               , th-abstraction >=0.3  && <0.4
+               , constraints    >=0.10 && <0.12
                , containers
                , deepseq
                , ghc-prim
-               , hashable == 1.2.*
-               , hashtables == 1.2.*
-               , lens >= 4.16 && <4.18
+               , hashable       >=1.2  && <1.4
+               , hashtables     ==1.2.*
+               , lens           >=4.16 && <4.19
                , mtl
                , template-haskell
                , text
-               , vector == 0.12.*
+               , vector         ==0.12.*
 
   hs-source-dirs: src
 

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -284,7 +284,7 @@ update vals (IndexThere th) upd =
     x :< rest -> x :< update rest th upd
 
 -- | Provides a lens for manipulating the element at the given index.
-indexed :: Index l x -> Lens.Simple Lens.Lens (List f l) (f x)
+indexed :: Index l x -> Lens.Lens' (List f l) (f x)
 indexed IndexHere      f (x :< rest) = (:< rest) <$> f x
 indexed (IndexThere i) f (x :< rest) = (x :<) <$> indexed i f rest
 


### PR DESCRIPTION
There are new versions of this package's dependencies to enable parameterized-utils to build on ghc 8.8.1