### PR TITLE
Use base-orphans to provide TestEquality instance for Compose

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -36,6 +36,7 @@ source-repository head
 
 library
   build-depends: base >= 4.10 && < 5
+               , base-orphans   >=0.8.2 && <0.9
                , th-abstraction >=0.3  && <0.4
                , constraints    >=0.10 && <0.12
                , containers

--- a/src/Data/Parameterized/Compose.hs
+++ b/src/Data/Parameterized/Compose.hs
@@ -16,12 +16,12 @@ https://github.com/haskell-compat/base-orphans/issues/49.
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE Safe #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Parameterized.Compose
   ( testEqualityComposeBare
   ) where
 
 import Data.Functor.Compose
+import Data.Orphans () -- For the TestEquality (Compose f g) instance
 import Data.Type.Equality
 
 -- | The deduction (via generativity) that if @g x :~: g y@ then @x :~: y@.
@@ -36,12 +36,3 @@ testEqualityComposeBare testEquality_ (Compose x) (Compose y) =
   case (testEquality_ x y :: Maybe (g x :~: g y)) of
     Just Refl -> Just (Refl :: x :~: y)
     Nothing   -> Nothing
-
-testEqualityCompose :: forall (f :: k -> *) (g :: l -> k) x y. (TestEquality f)
-                    => Compose f g x
-                    -> Compose f g y
-                    -> Maybe (x :~: y)
-testEqualityCompose = testEqualityComposeBare testEquality
-
-instance (TestEquality f) => TestEquality (Compose f g) where
-  testEquality = testEqualityCompose

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -6,6 +6,7 @@ packages:
 extra-deps:
 - ansi-terminal-0.9.1@sha256:48f53532d0f365ffa568c8cf0adc84c66f800a7d80d3329e4f04fa75392f4af1
 - ansi-wl-pprint-0.6.9
+- base-orphans-0.8.2@sha256:40ef37ed043aac2cbb6c538fdebfc62e601ee65ee161e4a6327452133b574d7e,2958
 - bifunctors-5.5.5
 - concurrent-output-1.10.10
 - generic-deriving-1.13

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -3,4 +3,5 @@ resolver: lts-14.3
 packages:
 - .
 extra-deps:
+- base-orphans-0.8.2@sha256:40ef37ed043aac2cbb6c538fdebfc62e601ee65ee161e4a6327452133b574d7e,2958
 - th-abstraction-0.3.1.0@sha256:96042f6658f2dccfac03b33f0fd59f62b1f65b9b0a765d8a2ea6026f4081ee4a


### PR DESCRIPTION
GHC 8.10 will introduce a `TestEquality` instance for `Compose`, which clashes with the one that `parameterized-utils` currently defines in `Data.Parameterized.Compose` as an orphan instance. To achieve forward compatibility with 8.10, this patch removes `parameterized-utils`' orphan instance and replaces it with the one in `base-orphans`, the canonical home for orphan instances for types in the `base` library. (Note that on 8.10 or later, this will simply use the instance found in `base`—the orphan instance is only used on older GHCs for backwards compatibility.)