### PR TITLE
hashtable-linear: changes hashtable implementation to use Linear

### DIFF
--- a/src/Data/Parameterized/HashTable.hs
+++ b/src/Data/Parameterized/HashTable.hs
@@ -30,7 +30,7 @@ module Data.Parameterized.HashTable
 
 import Control.Applicative
 import Control.Monad.ST
-import qualified Data.HashTable.ST.Cuckoo as H
+import qualified Data.HashTable.ST.Linear as H
 import GHC.Exts (Any)
 import Unsafe.Coerce
 


### PR DESCRIPTION
...rather than Cuckoo.

This is needed because the "Cuckoo" implementation in `hashtables` appears to be buggy and not well-supported.