### PR TITLE
add CtxFlatten type family and flattenAssignment

### DIFF
--- a/src/Data/Parameterized/Ctx.hs
+++ b/src/Data/Parameterized/Ctx.hs
@@ -31,6 +31,7 @@ module Data.Parameterized.Ctx
   , CtxUpdate
   , CtxLookupRight
   , CtxUpdateRight
+  , CtxFlatten
   , CheckIx
   , ValidIx
   , FromLeft
@@ -101,3 +102,8 @@ type CtxLookup (n :: Nat) (ctx :: Ctx k)
 --   is out of range, the context is unchanged.
 type CtxUpdate (n :: Nat) (x :: k) (ctx :: Ctx k)
   = CtxUpdateRight (FromLeft ctx n) x ctx
+
+-- | Flatten a nested context
+type family CtxFlatten (ctx :: Ctx (Ctx a)) :: Ctx a where
+  CtxFlatten EmptyCtx = EmptyCtx
+  CtxFlatten (ctxs ::> ctx) = CtxFlatten ctxs <+> ctx


### PR DESCRIPTION
For some purposes, it is useful to forget the nested structure of a
context of contexts, flattening it into one large context.  This
commit introduces a type family CtxFlatten to capture this at the
type level.

At the value level, the relevant operation consists in flattening
an assignment of assignments over this context of contexts, into
a flat assignment.