### PR TITLE
add leftIndex and rightIndex to adjust indices

### DIFF
--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -75,6 +75,8 @@ module Data.Parameterized.Context.Safe
   , skipIndex
   , lastIndex
   , nextIndex
+  , leftIndex
+  , rightIndex
   , extendIndex
   , extendIndex'
   , forIndex
@@ -302,6 +304,17 @@ nextIndex sz = IndexHere sz
 -- | Return the last index of a element.
 lastIndex :: Size (ctx ::> tp) -> Index (ctx ::> tp) tp
 lastIndex (SizeSucc s) = IndexHere s
+
+-- | Adapts an index in the left hand context of an append operation.
+leftIndex :: Size r -> Index l tp -> Index (l <+> r) tp
+leftIndex sr il = extendIndex' (appendDiff sr) il
+
+-- | Adapts an index in the right hand context of an append operation.
+rightIndex :: Size l -> Size r -> Index r tp -> Index (l <+> r) tp
+rightIndex sl sr ir =
+  case viewIndex sr ir of
+    IndexViewInit i -> skipIndex (rightIndex sl (decSize sr) i)
+    IndexViewLast s -> lastIndex (incSize (addSize sl s))
 
 {-# INLINE extendIndex #-}
 extendIndex :: KnownDiff l r => Index l tp -> Index r tp

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -47,6 +47,8 @@ module Data.Parameterized.Context.Unsafe
   , skipIndex
   , lastIndex
   , nextIndex
+  , leftIndex
+  , rightIndex
   , extendIndex
   , extendIndex'
   , forIndex
@@ -262,6 +264,14 @@ nextIndex n = Index (sizeInt n)
 -- | Return the last index of a element.
 lastIndex :: Size (ctx ::> tp) -> Index (ctx ::> tp) tp
 lastIndex n = Index (sizeInt n - 1)
+
+-- | Adapts an index in the left hand context of an append operation.
+leftIndex :: Size r -> Index l tp -> Index (l <+> r) tp
+leftIndex _ (Index il) = Index il
+
+-- | Adapts an index in the right hand context of an append operation.
+rightIndex :: Size l -> Size r -> Index r tp -> Index (l <+> r) tp
+rightIndex (Size sl) _ (Index ir) = Index (sl + ir)
 
 {-# INLINE extendIndex #-}
 extendIndex :: KnownDiff l r => Index l tp -> Index r tp


### PR DESCRIPTION
Lifting an index from a context to an index into the append of that
context to some other context is a bit cumbersome.  This commit adds
this as utility functions leftIndex and rightIndex.