### PR TITLE
add functions to support left-appended Contexts

### DIFF
--- a/src/Data/Parameterized/Context.hs
+++ b/src/Data/Parameterized/Context.hs
@@ -240,11 +240,13 @@ last x =
 view :: forall f ctx . Assignment f ctx -> AssignView f ctx
 view = viewAssign
 
+-- | Return the prefix of an appended 'Assignment'
 take :: forall f ctx ctx'. Size ctx -> Size ctx' -> Assignment f (ctx <+> ctx') -> Assignment f ctx
 take sz sz' asgn =
   let diff = appendDiff sz' in
   generate sz (\i -> asgn ! extendIndex' diff i)
 
+-- | Return the suffix of an appended 'Assignment'
 drop :: forall f ctx ctx'. Size ctx -> Size ctx' -> Assignment f (ctx <+> ctx') -> Assignment f ctx'
 drop sz sz' asgn = generate sz' (\i -> asgn ! extendIndexAppendLeft sz sz' i)
 
@@ -315,11 +317,13 @@ extendEmbeddingRightDiff diff (CtxEmbedding sz' assgn) = CtxEmbedding (extSize s
 extendEmbeddingRight :: CtxEmbedding ctx ctx' -> CtxEmbedding ctx (ctx' ::> tp)
 extendEmbeddingRight = extendEmbeddingRightDiff knownDiff
 
+-- | Prove that the prefix of an appended context is embeddable in it
 appendEmbedding :: Size ctx -> Size ctx' -> CtxEmbedding ctx (ctx <+> ctx')
 appendEmbedding sz sz' = CtxEmbedding (addSize sz sz') (generate sz (extendIndex' diff))
   where
   diff = appendDiff sz'
 
+-- | Prove that the suffix of an appended context is embeddable in it
 appendEmbeddingLeft :: Size ctx -> Size ctx' -> CtxEmbedding ctx' (ctx <+> ctx')
 appendEmbeddingLeft sz sz' = CtxEmbedding (addSize sz sz') (generate sz' (extendIndexAppendLeft sz sz'))
 

--- a/src/Data/Parameterized/Context.hs
+++ b/src/Data/Parameterized/Context.hs
@@ -56,6 +56,7 @@ module Data.Parameterized.Context
   , Data.Parameterized.Context.last
   , Data.Parameterized.Context.view
   , Data.Parameterized.Context.take
+  , Data.Parameterized.Context.drop
   , forIndexM
   , generateSome
   , generateSomeM
@@ -75,6 +76,7 @@ module Data.Parameterized.Context
   , extendEmbeddingRight
   , extendEmbeddingBoth
   , appendEmbedding
+  , appendEmbeddingLeft
   , ctxeSize
   , ctxeAssignment
 
@@ -243,6 +245,9 @@ take sz sz' asgn =
   let diff = appendDiff sz' in
   generate sz (\i -> asgn ! extendIndex' diff i)
 
+drop :: forall f ctx ctx'. Size ctx -> Size ctx' -> Assignment f (ctx <+> ctx') -> Assignment f ctx'
+drop sz sz' asgn = generate sz' (\i -> asgn ! extendIndexAppendLeft sz sz' i)
+
 --------------------------------------------------------------------------------
 -- Context embedding.
 
@@ -314,6 +319,9 @@ appendEmbedding :: Size ctx -> Size ctx' -> CtxEmbedding ctx (ctx <+> ctx')
 appendEmbedding sz sz' = CtxEmbedding (addSize sz sz') (generate sz (extendIndex' diff))
   where
   diff = appendDiff sz'
+
+appendEmbeddingLeft :: Size ctx -> Size ctx' -> CtxEmbedding ctx' (ctx <+> ctx')
+appendEmbeddingLeft sz sz' = CtxEmbedding (addSize sz sz') (generate sz' (extendIndexAppendLeft sz sz'))
 
 extendEmbeddingBoth :: forall ctx ctx' tp. CtxEmbedding ctx ctx' -> CtxEmbedding (ctx ::> tp) (ctx' ::> tp)
 extendEmbeddingBoth ctxe = updated & ctxeAssignment %~ flip extend (nextIndex (ctxe ^. ctxeSize))

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -77,6 +77,7 @@ module Data.Parameterized.Context.Safe
   , nextIndex
   , extendIndex
   , extendIndex'
+  , extendIndexAppendLeft
   , forIndex
   , forIndexRange
   , intIndex
@@ -311,6 +312,12 @@ extendIndex = extendIndex' knownDiff
 extendIndex' :: Diff l r -> Index l tp -> Index r tp
 extendIndex' DiffHere idx = idx
 extendIndex' (DiffThere diff) idx = IndexThere (extendIndex' diff idx)
+
+{-# INLINE extendIndexAppendLeft #-}
+extendIndexAppendLeft :: Size l -> Size r -> Index r tp -> Index (l <+> r) tp
+extendIndexAppendLeft sz sz' idx = case viewIndex sz' idx of
+  IndexViewLast _ -> lastIndex (addSize sz sz')
+  IndexViewInit idx' -> skipIndex (extendIndexAppendLeft sz (decSize sz') idx')
 
 -- | Given a size @n@, an initial value @v0@, and a function @f@, the
 -- expression @forIndex n v0 f@ calls @f@ on each index less than @n@

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -309,11 +309,15 @@ extendIndex :: KnownDiff l r => Index l tp -> Index r tp
 extendIndex = extendIndex' knownDiff
 
 {-# INLINE extendIndex' #-}
+-- | Compute an 'Index' into a context @r@ from an 'Index' into
+-- a sub-context @l@ of @r@.
 extendIndex' :: Diff l r -> Index l tp -> Index r tp
 extendIndex' DiffHere idx = idx
 extendIndex' (DiffThere diff) idx = IndexThere (extendIndex' diff idx)
 
 {-# INLINE extendIndexAppendLeft #-}
+-- | Compute an 'Index' into an appended context from an 'Index' into
+-- its suffix.
 extendIndexAppendLeft :: Size l -> Size r -> Index r tp -> Index (l <+> r) tp
 extendIndexAppendLeft sz sz' idx = case viewIndex sz' idx of
   IndexViewLast _ -> lastIndex (addSize sz sz')

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -49,6 +49,7 @@ module Data.Parameterized.Context.Unsafe
   , nextIndex
   , extendIndex
   , extendIndex'
+  , extendIndexAppendLeft
   , forIndex
   , forIndexRange
   , intIndex
@@ -270,6 +271,10 @@ extendIndex = extendIndex' knownDiff
 {-# INLINE extendIndex' #-}
 extendIndex' :: Diff l r -> Index l tp -> Index r tp
 extendIndex' _ = unsafeCoerce
+
+{-# INLINE extendIndexAppendLeft #-}
+extendIndexAppendLeft :: Size l -> Size r -> Index r tp -> Index (l <+> r) tp
+extendIndexAppendLeft (Size l) _ (Index idx) = Index (idx + l)
 
 -- | Given a size @n@, an initial value @v0@, and a function @f@, the
 -- expression @forIndex n v0 f@ is equivalent to @v0@ when @n@ is

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -269,10 +269,14 @@ extendIndex :: KnownDiff l r => Index l tp -> Index r tp
 extendIndex = extendIndex' knownDiff
 
 {-# INLINE extendIndex' #-}
+-- | Compute an 'Index' into a context @r@ from an 'Index' into
+-- a sub-context @l@ of @r@.
 extendIndex' :: Diff l r -> Index l tp -> Index r tp
 extendIndex' _ = unsafeCoerce
 
 {-# INLINE extendIndexAppendLeft #-}
+-- | Compute an 'Index' into an appended context from an 'Index' into
+-- its suffix.
 extendIndexAppendLeft :: Size l -> Size r -> Index r tp -> Index (l <+> r) tp
 extendIndexAppendLeft (Size l) _ (Index idx) = Index (idx + l)
 

--- a/test/Test/Context.hs
+++ b/test/Test/Context.hs
@@ -180,5 +180,14 @@ contextTests = testGroup "Context" <$> return
         let z = x U.<++> y
         let x' = C.take (U.size x) (U.size y) z
         assert $ isJust $ testEquality x x'
-
+   , testProperty "append_take_drop" $ property $
+     do vals1 <- forAll genSomePayloadList
+        vals2 <- forAll genSomePayloadList
+        Some x <- return $ mkUAsgn vals1
+        Some y <- return $ mkUAsgn vals2
+        let z = x U.<++> y
+        let x' = C.take (U.size x) (U.size y) z
+        let y' = C.drop (U.size x) (U.size y) z
+        assert $ isJust $ testEquality x x'
+        assert $ isJust $ testEquality y y'
    ]

--- a/test/Test/Context.hs
+++ b/test/Test/Context.hs
@@ -11,6 +11,7 @@ where
 import           Control.Lens
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as C
+import qualified Data.Parameterized.Ctx.Proofs as P
 import qualified Data.Parameterized.Context.Safe as S
 import qualified Data.Parameterized.Context.Unsafe as U
 import           Data.Parameterized.Some
@@ -172,6 +173,48 @@ contextTests = testGroup "Context" <$> return
           Just Refl -> vals1 === vals2
           Nothing   -> vals1 /== vals2
 
+   , testProperty "take none" $ property $
+     do vals1 <- forAll genSomePayloadList
+        vals2 <- forAll genSomePayloadList
+        vals3 <- forAll genSomePayloadList
+        Some w <- return $ mkUAsgn vals1
+        Some x <- return $ mkUAsgn vals2
+        Some y <- return $ mkUAsgn vals3
+        let z = w U.<++> x U.<++> y
+        case P.leftId z of
+          Refl -> let r = C.take U.zeroSize (U.size z) z in
+                    assert $ isJust $ testEquality U.empty r
+   , testProperty "drop none" $ property $
+     do vals1 <- forAll genSomePayloadList
+        vals2 <- forAll genSomePayloadList
+        vals3 <- forAll genSomePayloadList
+        Some w <- return $ mkUAsgn vals1
+        Some x <- return $ mkUAsgn vals2
+        Some y <- return $ mkUAsgn vals3
+        let z = w U.<++> x U.<++> y
+        case P.leftId z of
+          Refl -> let r = C.drop U.zeroSize (U.size z) z in
+                    assert $ isJust $ testEquality z r
+   , testProperty "take all" $ property $
+     do vals1 <- forAll genSomePayloadList
+        vals2 <- forAll genSomePayloadList
+        vals3 <- forAll genSomePayloadList
+        Some w <- return $ mkUAsgn vals1
+        Some x <- return $ mkUAsgn vals2
+        Some y <- return $ mkUAsgn vals3
+        let z = w U.<++> x U.<++> y
+        let r = C.take (U.size z) U.zeroSize z
+        assert $ isJust $ testEquality z r
+   , testProperty "drop all" $ property $
+     do vals1 <- forAll genSomePayloadList
+        vals2 <- forAll genSomePayloadList
+        vals3 <- forAll genSomePayloadList
+        Some w <- return $ mkUAsgn vals1
+        Some x <- return $ mkUAsgn vals2
+        Some y <- return $ mkUAsgn vals3
+        let z = w U.<++> x U.<++> y
+        let r = C.drop (U.size z) U.zeroSize z
+        assert $ isJust $ testEquality U.empty r
    , testProperty "append_take" $ property $
      do vals1 <- forAll genSomePayloadList
         vals2 <- forAll genSomePayloadList
@@ -190,4 +233,27 @@ contextTests = testGroup "Context" <$> return
         let y' = C.drop (U.size x) (U.size y) z
         assert $ isJust $ testEquality x x'
         assert $ isJust $ testEquality y y'
+   , testProperty "append_take_drop_multiple" $ property $
+     do vals1 <- forAll genSomePayloadList
+        vals2 <- forAll genSomePayloadList
+        vals3 <- forAll genSomePayloadList
+        vals4 <- forAll genSomePayloadList
+        vals5 <- forAll genSomePayloadList
+        Some u <- return $ mkUAsgn vals1
+        Some v <- return $ mkUAsgn vals2
+        Some w <- return $ mkUAsgn vals3
+        Some x <- return $ mkUAsgn vals4
+        Some y <- return $ mkUAsgn vals5
+        let uv = u U.<++> v
+        let wxy = w U.<++> x U.<++> y
+        -- let z = u C.<++> v C.<++> w C.<++> x C.<++> y
+        let z = uv U.<++> wxy
+        let uv' = C.take (U.size uv) (U.size wxy) z
+        let wxy' = C.drop (U.size uv) (U.size wxy) z
+        let withWXY = C.dropPrefix z uv (error "failed dropPrefix")
+        assert $ isJust $ testEquality (u U.<++> v) uv'
+        assert $ isJust $ testEquality (w U.<++> x U.<++> y) wxy'
+        assert $ isJust $ testEquality uv uv'
+        assert $ isJust $ testEquality wxy wxy'
+        withWXY $ \t -> assert $ isJust $ testEquality wxy' t
    ]


### PR DESCRIPTION
Adds equivalent Context operations that are now defined over the suffix of a Context-append, rather than the prefix.