### PR TITLE
Remove unnecessary CPP

### DIFF
--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -17,15 +17,11 @@ not restricted to '*'.
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Safe #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-#if MIN_VERSION_base(4,9,0)
-{-# LANGUAGE Safe #-}
-#else
-{-# LANGUAGE Trustworthy #-}
-#endif
 module Data.Parameterized.Classes
   ( -- * Equality exports
     Equality.TestEquality(..)

--- a/src/Data/Parameterized/Context.hs
+++ b/src/Data/Parameterized/Context.hs
@@ -205,10 +205,7 @@ pattern (:>) :: () => ctx' ~ (ctx ::> tp) => Assignment f ctx -> f tp -> Assignm
 pattern (:>) a v <- (viewAssign -> AssignExtend a v)
   where a :> v = extend a v
 
--- The COMPLETE pragma was not defined until ghc 8.2.*
-#if MIN_VERSION_base(4,10,0)
 {-# COMPLETE (:>), Empty :: Assignment  #-}
-#endif
 
 --------------------------------------------------------------------------------
 -- Views

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -115,11 +115,6 @@ import Data.Type.Equality
 import Prelude hiding (init, map, null, replicate, succ, zipWith)
 import Data.Kind(Type)
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Functor
-import Control.Applicative (Applicative(..))
-#endif
-
 import Data.Parameterized.Classes
 import Data.Parameterized.Ctx
 import Data.Parameterized.Some
@@ -492,12 +487,6 @@ adjustM f = go (\x -> x)
   go :: (forall tp'. g tp' -> f tp') -> Index ctx' tp -> Assignment g ctx' -> m (Assignment f ctx')
   go g (IndexHere _)     (AssignmentExtend asgn x) = AssignmentExtend (map g asgn) <$> f (g x)
   go g (IndexThere idx)  (AssignmentExtend asgn x) = flip AssignmentExtend (g x)   <$> go g idx asgn
-#if !MIN_VERSION_base(4,9,0)
--- GHC 7.10.3 and early does not recognize that the above definition is complete,
--- and so need the equation below.  GHC 8.0.1 does not require the additional
--- equation.
-  go _ _ _ = error "SafeTypeContext.adjustM: impossible!"
-#endif
 
 type instance IndexF   (Assignment (f :: k -> Type) ctx) = Index ctx
 type instance IxValueF (Assignment (f :: k -> Type) ctx) = f

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -394,17 +394,10 @@ instance TestEqualityFC (BalancedTree h) where
     Refl <- testEqualityFC test x1 y1
     Refl <- testEqualityFC test x2 y2
     return Refl
-#if !MIN_VERSION_base(4,9,0)
-  testEqualityFC _ _ _ = Nothing
-#endif
 
 instance OrdFC (BalancedTree h) where
   compareFC test (BalLeaf x) (BalLeaf y) =
     joinOrderingF (test x y) $ EQF
-#if !MIN_VERSION_base(4,9,0)
-  compareFC _ BalLeaf{} _ = LTF
-  compareFC _ _ BalLeaf{} = GTF
-#endif
   compareFC test (BalPair x1 x2) (BalPair y1 y2) =
     joinOrderingF (compareFC test x1 y1) $
     joinOrderingF (compareFC test x2 y2) $
@@ -518,9 +511,6 @@ bal_zipWithM f (BalLeaf x) (BalLeaf y) = BalLeaf <$> f x y
 bal_zipWithM f (BalPair x1 x2) (BalPair y1 y2) =
   BalPair <$> bal_zipWithM f x1 (unsafeCoerce y1)
           <*> bal_zipWithM f x2 (unsafeCoerce y2)
-#if !MIN_VERSION_base(4,9,0)
-bal_zipWithM _ _ _ = error "illegal args to bal_zipWithM"
-#endif
 {-# INLINABLE bal_zipWithM #-}
 
 ------------------------------------------------------------------------

--- a/src/Data/Parameterized/Map.hs
+++ b/src/Data/Parameterized/Map.hs
@@ -85,6 +85,7 @@ import           Control.Monad.Identity
 import           Data.Kind (Type)
 import           Data.List (intercalate, foldl')
 import           Data.Monoid
+import           Prelude hiding (filter, lookup, map, traverse, null)
 
 import           Data.Parameterized.Classes
 import           Data.Parameterized.Some
@@ -103,12 +104,6 @@ import           Data.Parameterized.Utils.BinTree
   , glue
   )
 import qualified Data.Parameterized.Utils.BinTree as Bin
-
-#if MIN_VERSION_base(4,8,0)
-import           Prelude hiding (filter, lookup, map, traverse, null)
-#else
-import           Prelude hiding (filter, lookup, map, null)
-#endif
 
 ------------------------------------------------------------------------
 -- * Pair

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -33,9 +33,7 @@ contained in a NatRepr value matches its static type.
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeApplications #-}
-#if MIN_VERSION_base(4,9,0)
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 805
 {-# LANGUAGE NoStarIsType #-}
 #endif

--- a/src/Data/Parameterized/Nonce.hs
+++ b/src/Data/Parameterized/Nonce.hs
@@ -24,9 +24,7 @@ if their values are equal.
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE Trustworthy #-}
-#if MIN_VERSION_base(4,9,0)
 {-# LANGUAGE TypeInType #-}
-#endif
 module Data.Parameterized.Nonce
   ( -- * NonceGenerator
     NonceGenerator
@@ -58,7 +56,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import Data.Parameterized.Classes
 import Data.Parameterized.Some
 
-#if MIN_VERSION_base(4,9,0) && __GLASGOW_HASKELL__ < 805
+#if __GLASGOW_HASKELL__ < 805
 import Data.Kind
 #endif
 
@@ -70,12 +68,7 @@ data NonceGenerator (m :: * -> *) (s :: *) where
   STNG :: !(STRef t Word64) -> NonceGenerator (ST t) s
   IONG :: !(IORef Word64) -> NonceGenerator IO s
 
-#if MIN_VERSION_base(4,9,0)
--- We have to make the k explicit in GHC 8.0 to avoid a warning.
 freshNonce :: forall m s k (tp :: k) . NonceGenerator m s -> m (Nonce s tp)
-#else
-freshNonce :: forall m s (tp :: k) . NonceGenerator m s -> m (Nonce s tp)
-#endif
 freshNonce (IONG r) =
   atomicModifyIORef' r $ \n -> (n+1, Nonce n)
 freshNonce (STNG r) = do

--- a/src/Data/Parameterized/Peano.hs
+++ b/src/Data/Parameterized/Peano.hs
@@ -34,9 +34,7 @@ these type-level natural numbers is 'Word64'.
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-#if MIN_VERSION_base(4,9,0)
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 805
 {-# LANGUAGE NoStarIsType #-}
 #endif


### PR DESCRIPTION
Since `parameterized-utils` only supports GHC 8.2 or later, many uses of `MIN_VERSION_base` in the code aren't needed. This patch removes them, alphabetizing language extensions and imports as necessary.