### PR TITLE
Avoid a use of `error` with EmptyCase

### DIFF
--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -27,6 +27,7 @@
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -513,7 +514,7 @@ instance forall k (f :: k -> Type) ctx. IxedF' k (Assignment f ctx) where
 idxlookup :: (forall tp. a tp -> b tp) -> Assignment a ctx -> forall tp. Index ctx tp -> b tp
 idxlookup f (AssignmentExtend _   x) (IndexHere _) = f x
 idxlookup f (AssignmentExtend ctx _) (IndexThere idx) = idxlookup f ctx idx
-idxlookup _ AssignmentEmpty _ = error "Data.Parameterized.Context.Safe.lookup: impossible case"
+idxlookup _ AssignmentEmpty idx = case idx of {}
 
 -- | Return value of assignment.
 (!) :: Assignment f ctx -> Index ctx tp -> f tp


### PR DESCRIPTION
The `error` case of `idxlookup` claims to be impossible, but in practice, it is actually reachable:

```
λ> idxlookup id AssignmentEmpty undefined
*** Exception: Data.Parameterized.Context.Safe.lookup: impossible case
CallStack (from HasCallStack):
  error, called at src/Data/Parameterized/Context/Safe.hs:505:33 in parameterized-utils-2.1.1.0.99-inplace:Data.Parameterized.Context.Safe
```

We can at least avoid this `impossible case` error message by using `EmptyCase`, which this patch accomplishes.