### PR TITLE
Showf type synonym

### DIFF
--- a/src/Data/Parameterized/All.hs
+++ b/src/Data/Parameterized/All.hs
@@ -38,6 +38,7 @@
 ------------------------------------------------------------------------
 
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Data.Parameterized.All
@@ -58,9 +59,6 @@ instance FunctorF All where
 
 instance FoldableF All where
   foldMapF toMonoid (All x) = toMonoid x
-
-instance ShowF f => Show (All f) where
-  show (All fa) = showF fa
 
 instance EqF f => Eq (All f) where
   (All x) == (All y) = eqF x y

--- a/src/Data/Parameterized/BoolRepr.hs
+++ b/src/Data/Parameterized/BoolRepr.hs
@@ -98,8 +98,6 @@ instance Show (BoolRepr m) where
   show FalseRepr = "FalseRepr"
   show TrueRepr  = "TrueRepr"
 
-instance ShowF BoolRepr
-
 instance HashableF BoolRepr where
   hashWithSaltF = hashWithSalt
 

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -597,6 +597,9 @@ instance HashableF f => Hashable (Assignment f ctx) where
   hashWithSalt s AssignmentEmpty = s
   hashWithSalt s (AssignmentExtend asgn x) = (s `hashWithSalt` asgn) `hashWithSaltF` x
 
+instance ShowF f => Show (Assignment f ctx) where
+  show a = "[" ++ intercalate ", " (toList show a) ++ "]"
+
 instance FunctorFC Assignment where
   fmapFC = fmapFCDefault
 

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -37,6 +37,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -136,8 +137,6 @@ data Size (ctx :: Ctx k) where
 -- | Renders as integer literal
 instance Show (Size ctx) where
   show = show . sizeInt
-
-instance ShowF Size
 
 -- | Convert a context size to an 'Int'.
 sizeInt :: Size ctx -> Int
@@ -414,8 +413,6 @@ intIndex n sz = listToMaybe $ drop n $ indexList sz
 instance Show (Index ctx tp) where
    show = show . indexVal
 
-instance ShowF (Index ctx)
-
 -- | View of indexes as pointing to the last element in the
 -- index range or pointing to an earlier element in a smaller
 -- range.
@@ -423,7 +420,6 @@ data IndexView ctx tp where
   IndexViewLast :: Size  ctx   -> IndexView (ctx '::> t) t
   IndexViewInit :: Index ctx t -> IndexView (ctx '::> u) t
 
-instance ShowF (IndexView ctx)
 deriving instance Show (IndexView ctx tp)
 
 -- | Project an index
@@ -600,11 +596,6 @@ instance HashableF f => HashableF (Assignment f) where
 instance HashableF f => Hashable (Assignment f ctx) where
   hashWithSalt s AssignmentEmpty = s
   hashWithSalt s (AssignmentExtend asgn x) = (s `hashWithSalt` asgn) `hashWithSaltF` x
-
-instance ShowF f => Show (Assignment f ctx) where
-  show a = "[" ++ intercalate ", " (toList showF a) ++ "]"
-
-instance ShowF f => ShowF (Assignment f)
 
 instance FunctorFC Assignment where
   fmapFC = fmapFCDefault

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -145,8 +146,6 @@ sizeToNatRepr (Size n) = NatRepr (fromIntegral n)
 
 instance Show (Size ctx) where
   show (Size i) = show i
-
-instance ShowF Size
 
 -- | A context that can be determined statically at compiler time.
 class KnownContext (ctx :: Ctx k) where
@@ -335,8 +334,6 @@ intIndex i n | 0 <= i && i < sizeInt n = Just (Some (Index i))
 instance Show (Index ctx tp) where
    show = show . indexVal
 
-instance ShowF (Index ctx)
-
 -- | View of indexes as pointing to the last element in the
 -- index range or pointing to an earlier element in a smaller
 -- range.
@@ -345,7 +342,6 @@ data IndexView ctx tp where
   IndexViewInit :: !(Index ctx t) -> IndexView (ctx '::> u) t
 
 deriving instance Show (IndexView ctx tp)
-instance ShowF (IndexView ctx)
 
 -- | Project an index
 viewIndex :: Size ctx -> Index ctx tp -> IndexView ctx tp
@@ -454,10 +450,8 @@ traverse_bal = go
 {-# INLINABLE traverse_bal #-}
 
 instance ShowF f => Show (BalancedTree h f tp) where
-  show (BalLeaf x) = showF x
+  show (BalLeaf x) = show x
   show (BalPair x y) = "BalPair " Prelude.++ show x Prelude.++ " " Prelude.++ show y
-
-instance ShowF f => ShowF (BalancedTree h f)
 
 unsafe_bal_generate :: forall ctx h f t
                      . Int -- ^ Height of tree to generate
@@ -855,9 +849,7 @@ instance HashableF f => HashableF (Assignment f) where
   hashWithSaltF = hashWithSalt
 
 instance ShowF f => Show (Assignment f ctx) where
-  show a = "[" Prelude.++ intercalate ", " (toListFC showF a) Prelude.++ "]"
-
-instance ShowF f => ShowF (Assignment f)
+  show a = "[" Prelude.++ intercalate ", " (toListFC show a) Prelude.++ "]"
 
 {-# DEPRECATED adjust "Replace 'adjust f i asgn' with 'Lens.over (ixF i) f asgn' instead." #-}
 adjust :: (f tp -> f tp) -> Index ctx tp -> Assignment f ctx -> Assignment f ctx

--- a/src/Data/Parameterized/DataKind.hs
+++ b/src/Data/Parameterized/DataKind.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -33,8 +34,7 @@ snd (PairRepr _ b) = b
 $(return [])
 
 instance ( ShowF f, ShowF g ) => Show (PairRepr f g p) where
-  show (PairRepr a b) = showChar '(' . showsF a . showChar ',' . showsF b $ ")"
-instance ( ShowF f, ShowF g ) => ShowF (PairRepr f g)
+  show (PairRepr a b) = showChar '(' . shows a . showChar ',' . shows b $ ")"
 
 deriving instance ( Eq (f a), Eq (g b) ) => Eq (PairRepr f g '(a, b))
 instance ( TestEquality f, TestEquality g ) => TestEquality (PairRepr f g) where

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -126,6 +126,7 @@ use the 'Data.Parameterized.List.List' type for this purpose.
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -174,11 +175,9 @@ instance ShowF f => Show (List f sh) where
   showsPrec p (elt :< rest) = showParen (p > precCons) $
     -- Unlike a derived 'Show' instance, we don't print parens implied
     -- by right associativity.
-    showsPrecF (precCons+1) elt . showString " :< " . showsPrec 0 rest
+    showsPrec (precCons+1) elt . showString " :< " . showsPrec 0 rest
     where
       precCons = 5
-
-instance ShowF f => ShowF (List f)
 
 instance FunctorFC List where
   fmapFC _ Nil = Nil
@@ -250,8 +249,6 @@ data Index :: [k] -> k -> Type  where
 
 deriving instance Eq (Index l x)
 deriving instance Show  (Index l x)
-
-instance ShowF (Index l)
 
 instance TestEquality (Index l) where
   testEquality IndexHere IndexHere = Just Refl

--- a/src/Data/Parameterized/Map.hs
+++ b/src/Data/Parameterized/Map.hs
@@ -14,6 +14,7 @@ Some code was adapted from containers.
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
@@ -309,7 +310,7 @@ instance TraversableF (MapF ktp) where
   traverseF = traverse
 
 instance (ShowF ktp, ShowF rtp) => Show (MapF ktp rtp) where
-  show m = showMap showF showF m
+  show m = showMap show show m
 
 -- | Return all keys of the map in ascending order.
 keys :: MapF k a -> [Some k]

--- a/src/Data/Parameterized/NatRepr/Internal.hs
+++ b/src/Data/Parameterized/NatRepr/Internal.hs
@@ -86,8 +86,6 @@ instance PolyEq (NatRepr m) (NatRepr n) where
 instance Show (NatRepr n) where
   show (NatRepr n) = show n
 
-instance ShowF NatRepr
-
 instance HashableF NatRepr where
   hashWithSaltF = hashWithSalt
 

--- a/src/Data/Parameterized/Nonce.hs
+++ b/src/Data/Parameterized/Nonce.hs
@@ -142,8 +142,6 @@ instance OrdF (Nonce s) where
 instance HashableF (Nonce s) where
   hashWithSaltF s (Nonce x) = hashWithSalt s x
 
-instance ShowF (Nonce s)
-
 ------------------------------------------------------------------------
 -- * GlobalNonceGenerator
 

--- a/src/Data/Parameterized/Nonce/Unsafe.hs
+++ b/src/Data/Parameterized/Nonce/Unsafe.hs
@@ -77,8 +77,6 @@ instance OrdF Nonce where
 instance HashableF Nonce where
   hashWithSaltF s (Nonce x) = hashWithSalt s x
 
-instance ShowF Nonce
-
 {-# INLINE freshNonce #-}
 -- | Get a fresh index and increment the counter.
 freshNonce :: NonceGenerator s -> ST s (Nonce tp)

--- a/src/Data/Parameterized/Peano.hs
+++ b/src/Data/Parameterized/Peano.hs
@@ -274,8 +274,6 @@ instance PolyEq (PeanoRepr m) (PeanoRepr n) where
 instance Show (PeanoRepr p) where
   show p = show (peanoValue p)
 
-instance ShowF PeanoRepr
-
 instance HashableF PeanoRepr where
   hashWithSaltF = hashWithSalt
 

--- a/src/Data/Parameterized/Some.hs
+++ b/src/Data/Parameterized/Some.hs
@@ -37,9 +37,6 @@ instance HashableF f => Hashable (Some f) where
   hashWithSalt s (Some x) = hashWithSaltF s x
   hash (Some x) = hashF x
 
-instance ShowF f => Show (Some f) where
-  show (Some x) = showF x
-
 -- | Project out of Some.
 viewSome :: (forall tp . f tp -> r) -> Some f -> r
 viewSome f (Some x) = f x

--- a/src/Data/Parameterized/Some.hs
+++ b/src/Data/Parameterized/Some.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 module Data.Parameterized.Some
   ( Some(..)
@@ -36,6 +37,9 @@ instance OrdF f => Ord (Some f) where
 instance HashableF f => Hashable (Some f) where
   hashWithSalt s (Some x) = hashWithSaltF s x
   hash (Some x) = hashF x
+
+instance ShowF f => Show (Some f) where
+  show (Some x) = show x
 
 -- | Project out of Some.
 viewSome :: (forall tp . f tp -> r) -> Some f -> r

--- a/src/Data/Parameterized/SymbolRepr.hs
+++ b/src/Data/Parameterized/SymbolRepr.hs
@@ -105,8 +105,6 @@ instance Hashable (SymbolRepr nm) where
 instance Show (SymbolRepr nm) where
   show (SymbolRepr nm) = Text.unpack nm
 
-instance ShowF SymbolRepr
-
 
 -- | The SomeSym hides a Symbol parameter but preserves a
 -- KnownSymbol constraint on the hidden parameter.

--- a/test/Test/Context.hs
+++ b/test/Test/Context.hs
@@ -56,8 +56,6 @@ instance Show (Payload tp) where
   show (StringPayload x) = show x <> " :: String"
   show (BoolPayload x) = show x <> " :: Bool"
 
-instance ShowF Payload
-
 
 twiddle :: Payload a -> Payload a
 twiddle (IntPayload n) = IntPayload (n+1)
@@ -76,7 +74,6 @@ twiddle (BoolPayload b) = BoolPayload (not b)
 -- constraint.
 
 data MyMaybe t = (Show t) => MyJust t | MyNothing
-instance ShowF MyMaybe
 instance Show (MyMaybe t) where
   show (MyJust x) = "MyJust " <> show x
   show MyNothing = "MyNothing"


### PR DESCRIPTION
This replaces the `ShowF` class with a type synonym:

```
type ShowF f = forall tp . Show (f tp)
```

I don't know if we want this change, but I've made the PR to have a pros/cons discussion about it.

Pros
* Reduces boilerplate (no more `instance ShowF MyType`)
* For types defined elsewhere, we need orphan `instance ShowF` to get a `Show` instance on `List`, `Assignment`, etc. This makes that no longer necessary

Cons
* Drops support for GHC 8.4
* Have to define `instance Show (MyType a)`, rather than individual `instance Show (MyType Foo)`, `instance Show (MyType Bar)`