### PR TITLE
Feature/choice

### DIFF
--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -104,6 +104,9 @@ class EqF (f :: k -> Type) where
 instance Eq a => EqF (Const a) where
   eqF (Const x) (Const y) = x == y
 
+instance EqF Proxy where
+  eqF Proxy Proxy = True
+
 ------------------------------------------------------------------------
 -- PolyEq
 
@@ -272,6 +275,8 @@ showsF :: ShowF f => f tp -> String -> String
 showsF x = showsPrecF 0 x
 
 instance Show x => ShowF (Const x)
+
+instance ShowF Proxy
 
 ------------------------------------------------------------------------
 -- IxedF

--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -12,6 +12,7 @@ not restricted to '*'.
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -357,3 +358,6 @@ instance HashableF f => Hashable (TypeAp f tp) where
 -- kind @k@.
 class KnownRepr (f :: k -> Type) (ctx :: k) where
   knownRepr :: f ctx
+
+instance KnownRepr Proxy ctx where
+  knownRepr = Proxy

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -462,7 +462,6 @@ fromChoice ix a (Choice ix' b)
 data ChoiceList f tp = ChoiceList [f tp]
 
 deriving instance Show (f tp) => Show (ChoiceList f tp)
-
 instance (forall tp . Show (f tp)) => ShowF (ChoiceList f)
 
 -- | Partition a list of 'Choice' into @n@ lists, where @n@ is the number of

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -459,7 +459,7 @@ fromChoice ix a (Choice ix' b)
   | Just Refl <- ix `testEquality` ix' = b
   | otherwise = a
 
--- | Type for the result of 'partitionChoices'.
+-- | Wrapper type for the result of 'partitionChoices'.
 data ChoiceList f tp = ChoiceList [f tp]
 
 deriving instance Show (f tp) => Show (ChoiceList f tp)

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -154,6 +154,7 @@ module Data.Parameterized.List
     -- * Choice
   , Choice(..)
   , choice
+  , ichoice
   , choose
   , isChoice
   , fromChoice
@@ -434,6 +435,10 @@ instance (forall tp . Show (f tp)) => ShowF (Choice f)
 -- | Case analysis for the 'Choice' type. Analogous to 'either'.
 choice :: (forall tp . f tp -> c) -> Choice f tps -> c
 choice f (Choice _ a) = f a
+
+-- | 'choice', but the function can use the 'Index'.
+ichoice :: (forall tp . Index tps tp -> f tp -> c) -> Choice f tps -> c
+ichoice f (Choice i a) = f i a
 
 -- | Extracts from a list of 'Choice' all the elements of a particular index.
 -- All such elements are extracted in order. Analogous to 'Data.Either.lefts'

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -416,6 +416,9 @@ itraverse f = go id
         Nil -> pure Nil
         e :< rest -> (:<) <$> f (g IndexHere) e <*> go (\ix -> g (IndexThere ix)) rest
 
+--------------------------------------------------------------------------------
+-- Choice and associated functions
+
 -- | Generalization of 'Either' for an arbitrary list of types.
 data Choice (f :: k -> Type) (tps :: [k]) where
   Choice :: Index tps tp -> f tp -> Choice f tps

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -158,6 +158,7 @@ module Data.Parameterized.List
   , isChoice
   , fromChoice
   , partitionChoices
+  , ChoiceList(..)
   ) where
 
 import qualified Control.Lens as Lens


### PR DESCRIPTION
I found a use for this; it's a sum type to `List`'s product.

Don't know if it should be in a separate module, like `Data.Choice.List` or `Data.List.Choice` (since it relies on `Data.List`, and we might want to make another version that uses `Assignment`s at some point).

Not sure if it needs to be in `parameterized-utils` at all, but it would seem strange to omit it, since it is dual to `List`.