### PR TITLE
Adds TH primitives for generating reprs

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -132,13 +132,3 @@ test-suite parameterizedTests
                , tasty-ant-xml == 1.1.*
                , tasty-hunit >= 0.9 && < 0.11
                , tasty-hedgehog
-
-executable foo
-  hs-source-dirs: .
-  main-is: Foo.hs
-  build-depends: base
-               , parameterized-utils
-               , template-haskell
-               , th-abstraction
-               , pretty-show
-  ghc-options: -ddump-splices

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -117,6 +117,7 @@ test-suite parameterizedTests
     Test.List
     Test.NatRepr
     Test.SymbolRepr
+    Test.TH
     Test.Vector
 
   build-depends: base
@@ -131,3 +132,13 @@ test-suite parameterizedTests
                , tasty-ant-xml == 1.1.*
                , tasty-hunit >= 0.9 && < 0.11
                , tasty-hedgehog
+
+executable foo
+  hs-source-dirs: .
+  main-is: Foo.hs
+  build-depends: base
+               , parameterized-utils
+               , template-haskell
+               , th-abstraction
+               , pretty-show
+  ghc-options: -ddump-splices

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -715,9 +715,9 @@ getCtorName c = case c of
 --
 -- Assuming the user of @parameterized-utils@ follows this convention, we
 -- provide the Template Haskell construct 'mkRepr' to automate the creation of
--- the @TRepr@ GADT type. We also provide 'mkKnownReprs', which generates
--- 'KnownRepr' instances for that GADT type. See the documentation for those two
--- functions for more detailed explanations.
+-- the @TRepr@ GADT. We also provide 'mkKnownReprs', which generates 'KnownRepr'
+-- instances for that GADT type. See the documentation for those two functions
+-- for more detailed explanations.
 --
 -- NB: These macros are inspired by the corresponding macros provided by
 -- `singletons-th`, and the "repr" programming idiom is very similar to the one

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -718,3 +718,7 @@ getCtorName c = case c of
 -- the @TRepr@ GADT type. We also provide 'mkKnownReprs', which generates
 -- 'KnownRepr' instances for that GADT type. See the documentation for those two
 -- functions for more detailed explanations.
+--
+-- NB: These macros are inspired by the corresponding macros provided by
+-- `singletons-th`, and the "repr" programming idiom is very similar to the one
+-- used by `singletons.`

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -25,6 +25,10 @@ module Data.Parameterized.TH.GADT
   , structuralHash
   , structuralHashWithSalt
   , PolyEq(..)
+    -- * Repr generators ("singletons")
+    -- $reprs
+  , mkRepr
+  , mkKnownReprs
     -- * Template haskell utilities that may be useful in other contexts.
   , DataD
   , lookupDataType'
@@ -493,6 +497,151 @@ showCon p nm n = do
 matchShowCtor :: ExpQ -> ConstructorInfo -> MatchQ
 matchShowCtor p con = showCon p (constructorName con) (length (constructorFields con))
 
+-- | Generate a "repr" or singleton type from a data kind. For nullary
+-- constructors, this works as follows:
+--
+-- @
+-- data T1 = A | B | C
+-- \$(mkRepr ''T1)
+-- ======>
+-- data T1Repr (tp :: T1)
+--   where
+--     ARepr :: T1Repr 'A
+--     BRepr :: T1Repr 'B
+--     CRepr :: T1Repr 'C
+-- @
+--
+-- For constructors with fields, we assume each field type @T@ already has a
+-- corresponding repr type @TRepr :: T -> *@.
+--
+-- @
+-- data T2 = T2_1 T1 | T2_2 T1
+-- \$(mkRepr ''T2)
+-- ======>
+-- data T2Repr (tp :: T2)
+--   where
+--     T2_1Repr :: T1Repr tp -> T2Repr ('T2_1 tp)
+--     T2_2Repr :: T1Repr tp -> T2Repr ('T2_2 tp)
+-- @
+--
+-- Constructors with multiple fields work fine as well:
+--
+-- @
+-- data T3 = T3 T1 T2
+-- \$(mkRepr ''T3)
+-- ======>
+-- data T3Repr (tp :: T3)
+--   where
+--     T3Repr :: T1Repr tp1 -> T2Repr tp2 -> T3Repr ('T3 tp1 tp2)
+-- @
+--
+-- This is generally compatible with other "repr" types provided by
+-- @parameterized-utils@, such as @NatRepr@ and @PeanoRepr@:
+--
+-- @
+-- data T4 = T4_1 Nat | T4_2 Peano
+-- \$(mkRepr ''T4)
+-- ======>
+-- data T4Repr (tp :: T4)
+--   where
+--     T4Repr :: NatRepr tp1 -> PeanoRepr tp2 -> T4Repr ('T4 tp1 tp2)
+-- @
+mkRepr :: Name -> DecsQ
+mkRepr typeName = do
+  let reprTypeName = mkReprName typeName
+      varName = mkName "tp"
+  info <- lookupDataType' typeName
+  let gc ci = do
+        let ctorName = constructorName ci
+            reprCtorName = mkReprName ctorName
+            ctorFieldTypeNames = getCtorName <$> constructorFields ci
+            ctorFieldReprNames = mkReprName <$> ctorFieldTypeNames
+        -- Attempt to reify the repr type to make sure it is in scope.
+        _ <- mapM_ lookupDataType' ctorFieldReprNames
+        -- Generate a list of type variables to be supplied as type arguments
+        -- for each repr argument.
+        tvars <- replicateM (length (constructorFields ci)) (newName "tp")
+        let appliedType = 
+              foldl AppT (PromotedT (constructorName ci)) (VarT <$> tvars)
+            ctorType = AppT (ConT reprTypeName) appliedType
+            ctorArgTypes =
+              zipWith (\n v -> (Bang NoSourceUnpackedness NoSourceStrictness, AppT (ConT n) (VarT v))) ctorFieldReprNames tvars
+        return $ GadtC
+          [reprCtorName]
+          ctorArgTypes
+          ctorType
+  ctors <- mapM gc (datatypeCons info)
+  return $ [ DataD [] reprTypeName
+             [KindedTV varName () (ConT typeName)]
+             Nothing
+             ctors
+             []
+           ]
+
+-- | Generate @KnownRepr@ instances for each constructor of a data kind. Given a
+-- data kind @T@, we assume a repr type @TRepr (t :: T)@ is in scope with
+-- structure that perfectly matches @T@ (using 'mkRepr' to generate the repr
+-- type will guarantee this).
+--
+-- Given data kinds @T1@, @T2@, and @T3@ from the documentation of 'mkRepr', and
+-- the associated repr types @T1Repr@, @T2Repr@, and @T3Repr@, we can use
+-- 'mkKnownReprs' to generate these instances like so:
+--
+-- @
+-- \$(mkKnownReprs ''T1)
+-- ======>
+-- instance KnownRepr T1Repr 'A where
+--   knownRepr = ARepr
+-- instance KnownRepr T1Repr 'B where
+--   knownRepr = BRepr
+-- instance KnownRepr T1Repr 'C where
+--   knownRepr = CRepr
+-- @
+--
+-- @
+-- \$(mkKnownReprs ''T2)
+-- ======>
+-- instance KnownRepr T1Repr tp =>
+--          KnownRepr T2Repr ('T2_1 tp) where
+--   knownRepr = T2_1Repr knownRepr
+-- @
+--
+-- @
+-- \$(mkKnownReprs ''T3)
+-- ======>
+-- instance (KnownRepr T1Repr tp1, KnownRepr T2Repr tp2) =>
+--          KnownRepr T3Repr ('T3_1 tp1 tp2) where
+--   knownRepr = T3_1Repr knownRepr knownRepr
+-- @
+mkKnownReprs :: Name -> DecsQ
+mkKnownReprs typeName = do
+  kr <- [t|KnownRepr|]
+  let krFName = mkName "knownRepr"
+      reprTypeName = mkReprName typeName
+  typeInfo <- lookupDataType' typeName
+  reprInfo <- lookupDataType' reprTypeName
+  forM (zip (datatypeCons typeInfo) (datatypeCons reprInfo)) $ \(tci, rci) -> do
+    vars <- forM (constructorFields tci) $ const (newName "tp")
+    krReqs <- forM (zip (constructorFields tci) vars) $ \(tfld, v) -> do
+      let fldReprName = mkReprName (getCtorName tfld)
+      return $ AppT (AppT kr (ConT fldReprName)) (VarT v)
+    let appliedType =
+          foldl AppT (PromotedT (constructorName tci)) (VarT <$> vars)
+        krConstraint = AppT (AppT kr (ConT reprTypeName)) appliedType
+        krExp = foldl AppE (ConE (constructorName rci)) $
+          map (const (VarE krFName)) vars
+        krDec = FunD krFName [Clause [] (NormalB krExp) []]
+
+    return $ InstanceD Nothing krReqs krConstraint [krDec]
+
+mkReprName :: Name -> Name
+mkReprName nm = mkName (nameBase nm ++ "Repr")
+
+getCtorName :: Type -> Name
+getCtorName c = case c of
+  ConT nm -> nm
+  _ -> error $ "expected constructor, found " ++ show c
+
 -- $typePatterns
 --
 -- The Template Haskell instance generators 'structuralEquality',
@@ -532,3 +681,40 @@ matchShowCtor p con = showCon p (constructorName con) (length (constructorFields
 --
 -- The use of 'DataArg' says that the type parameter of the 'NatRepr' must
 -- be the same as the second type parameter of @T@.
+
+-- $reprs
+--
+-- When working with data kinds with run-time representatives, we encourage
+-- users of @parameterized-utils@ to use the following convention. Given a data
+-- kind defined by
+--
+-- @
+-- data T = ...
+-- @
+--
+-- users should also supply a GADT @TRepr@ parameterized by @T@, e.g.
+--
+-- @
+-- data TRepr (t :: T) where ...
+-- @
+--
+-- Each constructor of @TRepr@ should correspond to a constructor of @T@. If @T@
+-- is defined by
+--
+-- @
+-- data T = A | B Nat
+-- @
+--
+-- we have a corresponding
+--
+-- @
+-- data TRepr (t :: T) where
+--   ARepr :: TRepr 'A
+--   BRepr :: NatRepr w -> TRepr ('B w)
+-- @
+--
+-- Assuming the user of @parameterized-utils@ follows this convention, we
+-- provide the template haskell constructs 'mkRepr' to automate the creation of
+-- the @TRepr@ GADT type. We also provide 'mkKnownReprs', which generates
+-- 'KnownRepr' instances for that GADT type. See the documentation for those two
+-- functions for more detailed explanations.

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -581,7 +581,7 @@ mkRepr typeName = do
           ctorType
   ctors <- mapM gc (datatypeCons info)
   return $ [ DataD [] reprTypeName
-             [KindedTV varName () (ConT typeName)]
+             [kindedTV varName (ConT typeName)]
              Nothing
              ctors
              []

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -561,7 +561,7 @@ mkRepr typeName = do
         -- Generate a list of type variables to be supplied as type arguments
         -- for each repr argument.
         tvars <- replicateM (length (constructorFields ci)) (newName "tp")
-        let appliedType = 
+        let appliedType =
               foldl AppT (PromotedT (constructorName ci)) (VarT <$> tvars)
             ctorType = AppT (ConT reprTypeName) appliedType
             ctorArgTypes =

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -714,7 +714,7 @@ getCtorName c = case c of
 -- @
 --
 -- Assuming the user of @parameterized-utils@ follows this convention, we
--- provide the template haskell constructs 'mkRepr' to automate the creation of
+-- provide the Template Haskell construct 'mkRepr' to automate the creation of
 -- the @TRepr@ GADT type. We also provide 'mkKnownReprs', which generates
 -- 'KnownRepr' instances for that GADT type. See the documentation for those two
 -- functions for more detailed explanations.

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -556,8 +556,6 @@ mkRepr typeName = do
             reprCtorName = mkReprName ctorName
             ctorFieldTypeNames = getCtorName <$> constructorFields ci
             ctorFieldReprNames = mkReprName <$> ctorFieldTypeNames
-        -- Attempt to reify the repr type to make sure it is in scope.
-        _ <- mapM_ lookupDataType' ctorFieldReprNames
         -- Generate a list of type variables to be supplied as type arguments
         -- for each repr argument.
         tvars <- replicateM (length (constructorFields ci)) (newName "tp")

--- a/src/Data/Parameterized/TH/GADT.hs
+++ b/src/Data/Parameterized/TH/GADT.hs
@@ -570,6 +570,15 @@ matchShowCtor p con = showCon p (constructorName con) (length (constructorFields
 --     Exception when trying to run compile-time code:
 --       mkRepr cannot be used on this data kind.
 -- @
+--
+-- Note that at a minimum, you will need the following extensions to use this macro:
+--
+-- @
+-- {-# LANGUAGE DataKinds #-}
+-- {-# LANGUAGE GADTs #-}
+-- {-# LANGUAGE KindSignatures #-}
+-- {-# LANGUAGE TemplateHaskell #-}
+-- @
 mkRepr :: Name -> DecsQ
 mkRepr typeName = do
   let reprTypeName = mkReprName typeName
@@ -644,6 +653,19 @@ mkRepr typeName = do
 -- The same restrictions that apply to 'mkRepr' also apply to 'mkKnownReprs'.
 -- The data kind must be \"simple\", i.e. it must be monomorphic and only
 -- contain user-defined data constructors (no lists, tuples, etc.).
+--
+-- Note that at a minimum, you will need the following extensions to use this macro:
+--
+-- @
+-- {-# LANGUAGE DataKinds #-}
+-- {-# LANGUAGE GADTs #-}
+-- {-# LANGUAGE KindSignatures #-}
+-- {-# LANGUAGE MultiParamTypeClasses #-}
+-- {-# LANGUAGE TemplateHaskell #-}
+-- @
+--
+-- Also, 'mkKnownReprs' must be used in the same module as the definition of
+-- both the repr type (not necessarily for the data kind).
 mkKnownReprs :: Name -> DecsQ
 mkKnownReprs typeName = do
   kr <- [t|KnownRepr|]

--- a/test/Test/TH.hs
+++ b/test/Test/TH.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.TH
+  ( thTests
+  )
+where
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Control.Monad (when)
+import           Data.Parameterized.Classes
+import           Data.Parameterized.NatRepr
+import           Data.Parameterized.TH.GADT
+import           GHC.TypeNats
+
+data T1 = A | B | C
+$(mkRepr ''T1)
+$(mkKnownReprs ''T1)
+$(return [])
+instance TestEquality T1Repr where
+  testEquality = $(structuralTypeEquality [t|T1Repr|] [])
+deriving instance Show (T1Repr t)
+
+data T2 = T2_1 T1 | T2_2 Nat
+$(mkRepr ''T2)
+$(mkKnownReprs ''T2)
+$(return [])
+instance TestEquality T2Repr where
+  testEquality = $(structuralTypeEquality [t|T2Repr|]
+                    [ (AnyType, [|testEquality|]) ])
+deriving instance Show (T2Repr t)
+
+eqTest :: (TestEquality f, Show (f a), Show (f b)) => f a -> f b -> IO ()
+eqTest a b =
+  when (not (isJust (testEquality a b))) $ assertFailure $ show a ++ " /= " ++ show b
+
+neqTest :: (TestEquality f, Show (f a), Show (f b)) => f a -> f b -> IO ()
+neqTest a b =
+  when (isJust (testEquality a b)) $ assertFailure $ show a ++ " == " ++ show b
+
+thTests :: IO TestTree
+thTests = testGroup "TH" <$> return
+  [ testCase "Repr equality test" $ do
+      -- T1
+      ARepr `eqTest` ARepr
+      ARepr `neqTest` BRepr
+      BRepr `eqTest` BRepr
+      BRepr `neqTest` CRepr
+      -- T2
+      T2_1Repr ARepr `eqTest` T2_1Repr ARepr
+      T2_2Repr (knownNat @5) `eqTest` T2_2Repr (knownNat @5)
+      T2_1Repr ARepr `neqTest` T2_1Repr CRepr
+      T2_2Repr (knownNat @5) `neqTest` T2_2Repr (knownNat @9)
+      T2_1Repr BRepr `neqTest` T2_2Repr (knownNat @4)
+
+  , testCase "KnownRepr test" $ do
+      -- T1
+      let aRepr = knownRepr :: T1Repr 'A
+          bRepr = knownRepr :: T1Repr 'B
+          cRepr = knownRepr :: T1Repr 'C
+      aRepr `eqTest` ARepr
+      bRepr `eqTest` BRepr
+      cRepr `eqTest` CRepr
+      --T2
+      let t2ARepr = knownRepr :: T2Repr ('T2_1 'A)
+          t2BRepr = knownRepr :: T2Repr ('T2_1 'B)
+          t25Repr = knownRepr :: T2Repr ('T2_2 5)
+      t2ARepr `eqTest` T2_1Repr ARepr
+      t2BRepr `eqTest` T2_1Repr BRepr
+      t25Repr `eqTest` T2_2Repr (knownNat @5)
+      t2ARepr `neqTest` t2BRepr
+      t2ARepr `neqTest` t25Repr
+      t2BRepr `neqTest` t25Repr
+  ]

--- a/test/UnitTest.hs
+++ b/test/UnitTest.hs
@@ -6,6 +6,7 @@ import qualified Test.Context
 import qualified Test.List
 import qualified Test.NatRepr
 import qualified Test.SymbolRepr
+import qualified Test.TH
 import qualified Test.Vector
 
 main :: IO ()
@@ -24,5 +25,6 @@ tests = testGroup "ParameterizedUtils" <$> sequence
   , pure Test.List.tests
   , Test.NatRepr.natTests
   , Test.SymbolRepr.symbolTests
+  , Test.TH.thTests
   , Test.Vector.vecTests
   ]


### PR DESCRIPTION
`mkRepr` generates runtime repr types for a given data kind (just like the singletons library). `mkKnownRepr `generates `KnownRepr` instances for data kinds.