### PR TITLE
TraversableFCWithIndex: Indexed traversals, folds, and maps

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -60,6 +60,7 @@ library
                , hashtables     ==1.2.*
                , lens           >=4.16 && <5.1
                , mtl
+               , profunctors
                , template-haskell
                , text
                , vector         ==0.12.*
@@ -95,6 +96,7 @@ library
     Data.Parameterized.TH.GADT
     Data.Parameterized.TraversableF
     Data.Parameterized.TraversableFC
+    Data.Parameterized.TraversableFC.WithIndex
     Data.Parameterized.Utils.BinTree
     Data.Parameterized.Utils.Endian
     Data.Parameterized.Vector

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -124,6 +124,7 @@ import Data.Parameterized.Ctx
 import Data.Parameterized.NatRepr
 import Data.Parameterized.Some
 import Data.Parameterized.TraversableFC
+import Data.Parameterized.TraversableFC.WithIndex
 
 ------------------------------------------------------------------------
 -- Size
@@ -615,6 +616,15 @@ instance FoldableFC Assignment where
 instance TraversableFC Assignment where
   traverseFC f = traverseF f
 
+instance FunctorFCWithIndex Assignment where
+  imapFC = imapFCDefault
+
+instance FoldableFCWithIndex Assignment where
+  ifoldMapFC = ifoldMapFCDefault
+
+instance TraversableFCWithIndex Assignment where
+  itraverseFC = traverseWithIndex
+
 -- | Map assignment
 map :: (forall tp . f tp -> g tp) -> Assignment f c -> Assignment g c
 map f = fmapFC f
@@ -650,6 +660,7 @@ zipWith :: (forall x . f x -> g x -> h x)
 zipWith f = \x y -> runIdentity $ zipWithM (\u v -> pure (f u v)) x y
 {-# INLINE zipWith #-}
 
+-- | This is a specialization of 'itraverseFC'.
 traverseWithIndex :: Applicative m
                   => (forall tp . Index ctx tp -> f tp -> m (g tp))
                   -> Assignment f ctx

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -106,6 +106,7 @@ import           Data.Parameterized.NatRepr
 import           Data.Parameterized.NatRepr.Internal (NatRepr(NatRepr))
 import           Data.Parameterized.Some
 import           Data.Parameterized.TraversableFC
+import           Data.Parameterized.TraversableFC.WithIndex
 
 ------------------------------------------------------------------------
 -- Size
@@ -927,6 +928,16 @@ instance FoldableFC Assignment where
 instance TraversableFC Assignment where
   traverseFC = \f (Assignment x) -> Assignment <$> traverse_bin f x
   {-# INLINE traverseFC #-}
+
+instance FunctorFCWithIndex Assignment where
+  imapFC = imapFCDefault
+
+instance FoldableFCWithIndex Assignment where
+  ifoldMapFC = ifoldMapFCDefault
+
+instance TraversableFCWithIndex Assignment where
+  itraverseFC = traverseWithIndex
+
 
 traverseWithIndex :: Applicative m
                   => (forall tp . Index ctx tp -> f tp -> m (g tp))

--- a/src/Data/Parameterized/TraversableFC/WithIndex.hs
+++ b/src/Data/Parameterized/TraversableFC/WithIndex.hs
@@ -1,0 +1,175 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Data.Parameterized.TraversableFC.WithIndex
+-- Copyright        : (c) Galois, Inc 2021
+-- Maintainer       : Langston Barrett
+-- Description      : 'TraversableFC' classes, but with indices.
+--
+-- As in the package indexed-traversable.
+------------------------------------------------------------------------
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Data.Parameterized.TraversableFC.WithIndex
+  ( FunctorFCWithIndex(..)
+  , FoldableFCWithIndex(..)
+  , ifoldlMFC
+  , ifoldrMFC
+  , iallFC
+  , ianyFC
+  , TraversableFCWithIndex(..)
+  , imapFCDefault
+  , ifoldMapFCDefault
+  ) where
+
+import Data.Functor.Const (Const(Const, getConst))
+import Data.Functor.Identity (Identity(Identity, runIdentity))
+import Data.Kind
+import Data.Monoid (All(..), Any(..), Endo(Endo), appEndo, Dual(Dual, getDual))
+import Data.Profunctor.Unsafe ((#.))
+import GHC.Exts (build)
+
+import Data.Parameterized.Classes
+import Data.Parameterized.TraversableFC
+
+class FunctorFC t => FunctorFCWithIndex (t :: (k -> Type) -> l -> Type) where
+  -- | Like 'fmapFC', but with an index.
+  --
+  -- @
+  -- 'fmapFC' f ≡ 'imapFC' ('const' f)
+  -- @
+  imapFC ::
+    forall f g z.
+    (forall x. IndexF (t f z) x -> f x -> g x)
+    -> t f z
+    -> t g z
+
+------------------------------------------------------------------------
+
+class (FoldableFC t, FunctorFCWithIndex t) => FoldableFCWithIndex (t :: (k -> Type) -> l -> Type) where
+
+  -- | Like 'foldMapFC', but with an index.
+  --
+  -- @
+  -- 'foldMapFC' f ≡ 'ifoldMapFC' ('const' f)
+  -- @
+  ifoldMapFC ::
+    forall f m z.
+    Monoid m =>
+    (forall x. IndexF (t f z) x -> f x -> m) ->
+    t f z ->
+    m
+  ifoldMapFC f = ifoldrFC (\i x -> mappend (f i x)) mempty
+
+  -- | Like 'foldrFC', but with an index.
+  ifoldrFC ::
+    forall z f b.
+    (forall x. IndexF (t f z) x -> f x -> b -> b) ->
+    b ->
+    t f z ->
+    b
+  ifoldrFC f z t = appEndo (ifoldMapFC (\i x -> Endo (f i x)) t) z
+
+  -- | Like 'foldlFC', but with an index.
+  ifoldlFC ::
+    forall f b z.
+    (forall x. IndexF (t f z) x -> b -> f x -> b) ->
+    b ->
+    t f z ->
+    b
+  ifoldlFC f z t =
+    appEndo (getDual (ifoldMapFC (\i e -> Dual (Endo (\r -> f i r e))) t)) z
+
+  -- | Like 'ifoldrFC', but with an index.
+  ifoldrFC' ::
+    forall f b z.
+    (forall x. IndexF (t f z) x -> f x -> b -> b) ->
+    b ->
+    t f z ->
+    b
+  ifoldrFC' f0 z0 xs = ifoldlFC (f' f0) id xs z0
+    where f' f i k x z = k $! f i x z
+
+  -- | Like 'ifoldlFC', but with an index.
+  ifoldlFC' :: forall f b. (forall x. b -> f x -> b) -> (forall x. b -> t f x -> b)
+  ifoldlFC' f0 z0 xs = foldrFC (f' f0) id xs z0
+    where f' f x k z = k $! f z x
+
+  -- | Convert structure to list.
+  itoListFC ::
+    forall f a z.
+    (forall x. IndexF (t f z) x -> f x -> a) ->
+    t f z ->
+    [a]
+  itoListFC f t = build (\c n -> ifoldrFC (\i e v -> c (f i e) v) n t)
+
+-- | Like 'foldlMFC', but with an index.
+ifoldlMFC ::
+  FoldableFCWithIndex t =>
+  Monad m =>
+  (forall x. IndexF (t f z) x -> b -> f x -> m b) ->
+  b ->
+  t f z ->
+  m b
+ifoldlMFC f z0 xs = ifoldlFC (\i k x z -> f i z x >>= k) return xs z0
+
+-- | Like 'foldrMFC', but with an index.
+ifoldrMFC ::
+  FoldableFCWithIndex t =>
+  Monad m =>
+  (forall x. IndexF (t f z) x -> f x -> b -> m b) ->
+  b ->
+  t f z ->
+  m b
+ifoldrMFC f z0 xs = ifoldlFC (\i k x z -> f i x z >>= k) return xs z0
+
+-- | Like 'allFC', but with an index.
+iallFC ::
+  FoldableFCWithIndex t =>
+  (forall x. IndexF (t f z) x -> f x -> Bool) ->
+  t f z ->
+  Bool
+iallFC p = getAll #. ifoldMapFC (\i x -> All (p i x))
+
+-- | Like 'anyFC', but with an index.
+ianyFC ::
+  FoldableFCWithIndex t =>
+  (forall x. IndexF (t f z) x -> f x -> Bool) ->
+  t f z -> Bool
+ianyFC p = getAny #. ifoldMapFC (\i x -> Any (p i x))
+
+------------------------------------------------------------------------
+
+class (TraversableFC t, FoldableFCWithIndex t) => TraversableFCWithIndex (t :: (k -> Type) -> l -> Type) where
+  -- | Like 'traverseFC', but with an index.
+  --
+  -- @
+  -- 'traverseFC' f ≡ 'itraverseFC' ('const' f)
+  -- @
+  itraverseFC ::
+    forall m z f g.
+    Applicative m =>
+    (forall x. IndexF (t f z) x -> f x -> m (g x)) ->
+    t f z ->
+    m (t g z)
+
+imapFCDefault ::
+  forall t f g z.
+  TraversableFCWithIndex t =>
+  (forall x. IndexF (t f z) x -> f x -> g x)
+  -> t f z
+  -> t g z
+imapFCDefault f = runIdentity #. itraverseFC (\i x -> Identity (f i x))
+{-# INLINEABLE imapFCDefault #-}
+
+ifoldMapFCDefault ::
+  forall t m z f.
+  TraversableFCWithIndex t =>
+  Monoid m =>
+  (forall x. IndexF (t f z) x -> f x -> m) ->
+  t f z ->
+  m
+ifoldMapFCDefault f = getConst #. itraverseFC (\i x -> Const (f i x))
+{-# INLINEABLE ifoldMapFCDefault #-}


### PR DESCRIPTION
Add indexed functors, folds, and traversals inspired by the indexed-traversable
(which is where the naming scheme comes from) and lens packages.

The current contents of the List and Assignment modules provide additional
motivation: List already implements and exports a minimal set of methods for
each of the added classes, but Assignment only implemented
'traverseWithIndex' (AKA 'itraverseFC'); this indicates that identifying this
abstraction enables code sharing and increased functionality between these
similar modules/datatypes.

Additionally, Assignment now gets 'ifoldMapFC', 'imapFC' and friends "for free",
because they have default implementations based on 'itraverseFC'.

At some point, it may make sense to implement similar classes for the *F family:
'FunctorF', 'FoldableF', and 'TraversableF'. However, 'MapF' is the only
'TraversableF' that has an instance of 'IndexF', so this isn't as clearly a
code-sharing win, though such classes may uncover useful, as of yet
unimplemented functions for that API as the *FC ones did for 'Assignment'.