### PR TITLE
CI: Add configuration step that adds tests to Cabal build plan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Cabal check
         shell: bash
         run: cabal check
+      - name: Configure
+        shell: bash
+        run: cabal configure --enable-tests
       - name: Build
         shell: bash
         run: cabal build


### PR DESCRIPTION
Previously, tests were sometimes not included by Cabal in its build plan, leading to spurrious CI failures.

Fixes #118.