### PR TITLE
Document FunctorFC laws, test Assignment instance

### DIFF
--- a/src/Data/Parameterized/TraversableFC.hs
+++ b/src/Data/Parameterized/TraversableFC.hs
@@ -45,7 +45,12 @@ import Data.Type.Equality
 
 import Data.Parameterized.Classes
 
--- | A parameterized type that is a function on all instances.
+-- | A parameterized type that is a functor on all instances.
+--
+-- Laws:
+--
+-- [Identity]    @'fmapFC' 'id' == 'id'@
+-- [Composition] @'fmapFC' (f . g) == 'fmapFC' f . 'fmapFC' g@
 class FunctorFC (t :: (k -> Type) -> l -> Type) where
   fmapFC :: forall f g. (forall x. f x -> g x) ->
                         (forall x. t f x -> t g x)


### PR DESCRIPTION
I realized that the laws and tests I wrote for #117 implicitly relied on the assumption that the other *FC classes had laws and tests for those laws. This isn't all of them, but it's a start.

Also, strengthen a few existing *WithIndex tests.