### PR TITLE
{Functor,Foldable,Traversable}WithIndex instances for Vector

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -58,6 +58,7 @@ library
                , ghc-prim
                , hashable       >=1.2  && <1.4
                , hashtables     ==1.2.*
+               , indexed-traversable
                , lens           >=4.16 && <5.1
                , mtl
                , profunctors
@@ -127,6 +128,7 @@ test-suite parameterizedTests
                , hashable
                , hashtables
                , hedgehog
+               , indexed-traversable
                , ghc-prim
                , lens
                , mtl

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -137,3 +137,7 @@ test-suite parameterizedTests
                , tasty-ant-xml == 1.1.*
                , tasty-hunit >= 0.9 && < 0.11
                , tasty-hedgehog
+
+  if impl(ghc >= 8.6)
+    build-depends:
+      hedgehog-classes

--- a/src/Data/Parameterized/Vector.hs
+++ b/src/Data/Parameterized/Vector.hs
@@ -578,7 +578,9 @@ unfoldr :: forall h a b
        -> Vector (h + 1) a
 unfoldr h gen start = unfoldrWithIndex h (\_ v -> gen v) start
 
--- | Compare to 'Vector.iterateNM'
+-- | Build a vector by repeatedly applying a monadic function to a seed value.
+--
+-- Compare to 'Vector.iterateNM'.
 iterateNM :: Monad m => NatRepr n -> (a -> m a) -> a -> m (Vector (n + 1) a)
 iterateNM h f start =
   case isZeroNat h of
@@ -586,7 +588,9 @@ iterateNM h f start =
     NonZeroNat -> cons start <$> unfoldrM (predNat h) (fmap dup . f) start
   where dup x = (x, x)
 
--- | Compare to 'Vector.iterateN'
+-- | Build a vector by repeatedly applying a function to a seed value.
+--
+-- Compare to 'Vector.iterateN'
 iterateN :: NatRepr n -> (a -> a) -> a -> Vector (n + 1) a
 iterateN h f start = runIdentity (iterateNM h (Identity . f) start)
 

--- a/test/Test/Vector.hs
+++ b/test/Test/Vector.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE TypeApplications #-}
 {-# Language CPP #-}
 {-# Language DataKinds #-}
@@ -18,6 +19,8 @@ module Test.Vector
 where
 
 import           Data.Functor.Const (Const(..))
+import           Data.Functor.WithIndex (imap)
+import           Data.Foldable.WithIndex (ifoldMap)
 import           Data.Maybe (isJust)
 import qualified Data.List as List
 import qualified Data.Parameterized.Context as Ctx
@@ -29,15 +32,38 @@ import           GHC.TypeLits
 import           Hedgehog
 import qualified Hedgehog.Gen as HG
 import           Hedgehog.Range
-import           Prelude hiding (take, reverse)
+import           Numeric.Natural (Natural)
+import           Prelude hiding (take, reverse, length)
 import qualified Prelude as P
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 import           Test.Context (genSomePayloadList, mkUAsgn)
 
 
-genVector :: (1 <= n, KnownNat n, Monad m) => GenT m a -> GenT m (Vector n a)
-genVector genElem =
+data SomeVector a = forall n. SomeVector (Vector n a)
+
+instance Show a => Show (SomeVector a) where
+  show (SomeVector v) = show v
+
+genVectorOfLength :: (Monad m) => NatRepr n -> GenT m a -> GenT m (Vector (n + 1) a)
+genVectorOfLength n genElem =
+  do let w = widthVal n
+     l <- HG.list (linear (w + 1) (w + 1)) genElem
+     case testLeq (knownNat @1) (incNat n) of
+       Nothing -> error "testLeq in genSomeVector"
+       Just LeqProof ->
+         case fromList (incNat n) l of
+           Just v -> return v
+           Nothing -> error ("fromList failure for size " <> show w)
+
+genSomeVector :: (Monad m) => GenT m a -> GenT m (SomeVector a)
+genSomeVector genElem =
+  do Some len <- mkNatRepr <$> HG.integral (linear 0 (99 :: Natural))
+     SomeVector <$> genVectorOfLength len genElem
+
+
+genVectorKnownLength :: (1 <= n, KnownNat n, Monad m) => GenT m a -> GenT m (Vector n a)
+genVectorKnownLength genElem =
   do let n = knownNat
          w = widthVal n
      l <- HG.list (constant w w) genElem
@@ -48,17 +74,36 @@ genVector genElem =
 genOrdering :: Monad m => GenT m Ordering
 genOrdering = HG.element [ LT, EQ, GT ]
 
+genVectorIndex :: Monad m => NatRepr n -> GenT m (VectorIndex (n + 1))
+genVectorIndex n =
+  do i <- HG.int (linear 0 (fromIntegral (intValue n - 1)))
+     pure $ elemAtUnsafe i (indicesUpTo n)
 
 instance Show (a -> b) where
   show _ = "unshowable"
 
+orderToOrder :: [Ordering -> Ordering]
+orderToOrder =
+  [ const EQ
+  , id
+  , \case
+      EQ -> EQ
+      LT -> GT
+      GT -> LT
+  , \case
+      LT -> EQ
+      EQ -> GT
+      GT -> LT
+  ]
 
 -- We use @Ordering@ just because it's simple
 vecTests :: IO TestTree
 vecTests = testGroup "Vector" <$> return
   [ testProperty "reverse100" $ property $
-    do v <- forAll $ genVector @100 genOrdering
-       v === (reverse $ reverse v)
+    do SomeVector v <- forAll $ genSomeVector genOrdering
+       case testLeq (knownNat @1) (length v) of
+         Nothing -> pure ()
+         Just LeqProof -> v === (reverse $ reverse v)
   , testProperty "reverseSingleton" $ property $
     do l <- (:[]) <$> forAll genOrdering
        Just v <- return $ fromList (knownNat @1) l
@@ -66,7 +111,7 @@ vecTests = testGroup "Vector" <$> return
 
   , testProperty "split-join" $ property $
     do let n = knownNat @5
-       v <- forAll $ genVector @(5 * 5) genOrdering
+       v <- forAll $ genVectorKnownLength @(5 * 5) genOrdering
        v === (join n $ split n (knownNat @5) v)
 
   -- @cons@ is the same for vectors or lists
@@ -145,4 +190,62 @@ vecTests = testGroup "Vector" <$> return
                           testEquality
                             (a Ctx.! Ctx.lastIndex sz) lastElem)
                    (getConst (a' Ctx.! Ctx.lastIndex sz))
-    ]
+
+  , testProperty "fmap-id" $ property $
+    do SomeVector v <- forAll $ genSomeVector genOrdering
+       fmap id v === v
+
+  , testProperty "fmap-compose" $ property $
+    do SomeVector v <- forAll $ genSomeVector genOrdering
+       f <- forAll $ HG.element orderToOrder
+       g <- forAll $ HG.element orderToOrder
+       fmap (g . f) v === fmap g (fmap f v)
+
+  , testProperty "iterateN-range" $ property $
+    do Some len <- mkNatRepr <$> forAll (HG.integral (linear 0 (99 :: Natural)))
+       toList (iterateN len (+1) 0) === [0..(natValue len)]
+
+  , testProperty "indicesOf-range" $ property $
+    do SomeVector v <- forAll $ genSomeVector genOrdering
+       toList (fmap indexValue (indicesOf v)) === [0..(natValue (length v) - 1)]
+
+  , testProperty "imap-const" $ property $
+    do f <- forAll $ HG.element orderToOrder
+       SomeVector v <- forAll $ genSomeVector genOrdering
+       imap (const f) v === fmap f v
+
+  , testProperty "ifoldMap-const" $ property $
+    do let funs :: [ Ordering -> String ]
+           funs = [const "s", show]
+       f <- forAll $ HG.element funs
+       SomeVector v <- forAll $ genSomeVector genOrdering
+       ifoldMap (const f) v === foldMap f v
+
+  , testProperty "imap-const-indicesOf" $ property $
+    do SomeVector v <- forAll $ genSomeVector genOrdering
+       imap const v === indicesOf v
+
+  , testProperty "imap-elemAt" $ property $
+    do SomeVector v <- forAll $ genSomeVector genOrdering
+       imap (\(VectorIndex i) _ -> elemAt i v) v === v
+
+  , testProperty "Eq-VectorIndex-reflexive" $ property $
+    do i <- forAll $ genVectorIndex (knownNat @10)
+       i === i
+
+  , testProperty "Eq-VectorIndex-symmetric" $ property $
+    do i <- forAll $ genVectorIndex (knownNat @10)
+       j <- forAll $ genVectorIndex (knownNat @10)
+       (i == j) === (j == i)
+
+  , testProperty "Eq-VectorIndex-transitive" $ property $
+    do i <- forAll $ genVectorIndex (knownNat @10)
+       j <- forAll $ genVectorIndex (knownNat @10)
+       k <- forAll $ genVectorIndex (knownNat @10)
+       (((i == j) && (j == k)) <= (i == k)) === True
+
+  , testProperty "Ord-Eq-VectorIndex" $ property $
+    do i <- forAll $ genVectorIndex (knownNat @10)
+       j <- forAll $ genVectorIndex (knownNat @10)
+       (i == j) === (compare i j == EQ)
+  ]


### PR DESCRIPTION
Also:

- Add iterateNM and iterateN in the style of the vector package, to support the helper methods indicesUpTo and indicesOf.

- Improve test infrastructure by not fixing the sizes of vectors, but instead using genSomeVector

- Add tests of functor laws