### PR TITLE
Fin: Finite types

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ Additionally:
   run-time representative values for them.  It also provides some utilities for
   proving properties over Peano numbers.
 
+* Data.Parameterized.Fin
+
+  `Fin n` is a finite type with `n` (terminating/non-bottom) inhabitants. It can
+  be used to index into a `Vector n` or other size-indexed datatype.
+
 * Data.Parameterized.SymbolRepr
 
   This module provides run-time representative values for strings lifted to

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -83,6 +83,7 @@ library
     Data.Parameterized.Ctx.Proofs
     Data.Parameterized.DataKind
     Data.Parameterized.DecidableEq
+    Data.Parameterized.Fin
     Data.Parameterized.HashTable
     Data.Parameterized.List
     Data.Parameterized.Map
@@ -118,6 +119,7 @@ test-suite parameterizedTests
   main-is: UnitTest.hs
   other-modules:
     Test.Context
+    Test.Fin
     Test.List
     Test.NatRepr
     Test.SymbolRepr

--- a/src/Data/Parameterized/Fin.hs
+++ b/src/Data/Parameterized/Fin.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-|
+Copyright        : (c) Galois, Inc 2021
+
+@'Fin' n@ is a finite type with exactly @n@ elements. Essentially, they bundle a
+'NatRepr' that has an existentially-quantified type parameter with a proof that
+its parameter is less than some fixed natural.
+
+They are useful in combination with types of a fixed size. For example 'Fin' is
+used as the index in the 'Data.Functor.WithIndex.FunctorWithIndex' instance for
+'Data.Parameterized.Vector'. As another example, a @Map ('Fin' n) a@ is a @Map@
+that naturally has a fixed size bound of @n@.
+-}
+module Data.Parameterized.Fin
+  ( Fin
+  , mkFin
+  , viewFin
+  , finToNat
+  , embed
+  , tryEmbed
+  , minFin
+  , fin0Void
+  , fin1Unit
+  , fin2Bool
+  ) where
+
+import Control.Lens.Iso (Iso', iso)
+import GHC.TypeNats (KnownNat)
+import Numeric.Natural (Natural)
+import Data.Void (Void, absurd)
+
+import Data.Parameterized.NatRepr
+
+-- | The type @'Fin' n@ has exactly @n@ inhabitants.
+data Fin n =
+  -- GHC 8.6 and 8.4 require parentheses around 'i + 1 <= n'
+  forall i. (i + 1 <= n) => Fin { _getFin :: NatRepr i }
+
+instance Eq (Fin n) where
+  i == j = finToNat i == finToNat j
+
+instance Ord (Fin n) where
+  compare i j = compare (finToNat i) (finToNat j)
+
+instance (1 <= n, KnownNat n) => Bounded (Fin n) where
+  minBound = Fin (knownNat @0)
+  maxBound =
+    case minusPlusCancel (knownNat @n) (knownNat @1) of
+      Refl -> Fin (decNat (knownNat @n))
+
+-- | Non-lawful instance, intended only for testing.
+instance Show (Fin n) where
+  show i = "Fin " ++ show (finToNat i)
+
+mkFin :: forall i n. (i + 1 <= n) => NatRepr i -> Fin n
+mkFin = Fin
+
+viewFin ::  (forall i. (i + 1 <= n) => NatRepr i -> r) -> Fin n -> r
+viewFin f (Fin i) = f i
+
+finToNat :: Fin n -> Natural
+finToNat (Fin i) = natValue i
+
+embed :: forall n m. (n <= m) => Fin n -> Fin m
+embed =
+  viewFin
+    (\(x :: NatRepr o) ->
+      case leqTrans (LeqProof :: LeqProof (o + 1) n) (LeqProof :: LeqProof n m) of
+        LeqProof -> Fin x
+    )
+
+tryEmbed :: NatRepr n -> NatRepr m -> Fin n -> Maybe (Fin m)
+tryEmbed n m i =
+  case testLeq n m of
+    Just LeqProof -> Just (embed i)
+    Nothing -> Nothing
+
+-- | The smallest element of @'Fin' n@
+minFin :: (1 <= n) => Fin n
+minFin = Fin (knownNat @0)
+
+fin0Void :: Iso' (Fin 0) Void
+fin0Void =
+  iso
+    (viewFin
+      (\(x :: NatRepr o) ->
+        case plusComm x (knownNat @1) of
+          Refl ->
+            case addIsLeqLeft1 @1 @o @0 LeqProof of {}))
+    absurd
+
+fin1Unit :: Iso' (Fin 1) ()
+fin1Unit = iso (const ()) (const minFin)
+
+fin2Bool :: Iso' (Fin 2) Bool
+fin2Bool =
+  iso
+    (viewFin
+      (\n ->
+         case isZeroNat n of
+           ZeroNat -> False
+           NonZeroNat -> True))
+    (\b -> if b then maxBound else minBound)

--- a/test/Test/Fin.hs
+++ b/test/Test/Fin.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# Language CPP #-}
+
+module Test.Fin
+  ( finTests
+  , genFin
+  )
+where
+
+import           Numeric.Natural (Natural)
+
+import           Hedgehog
+import qualified Hedgehog.Gen as HG
+import           Hedgehog.Range (linear)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (assertBool, testCase)
+
+import           Data.Parameterized.NatRepr
+import           Data.Parameterized.Fin
+import           Data.Parameterized.Some (Some(Some))
+
+#if __GLASGOW_HASKELL__ >= 806
+import qualified Hedgehog.Classes as HC
+#endif
+
+genFin :: (0 <= n, Monad m) => NatRepr n -> GenT m (Fin n)
+genFin n =
+  do x0 <- HG.integral (linear 0 ((natValue n) - 1 :: Natural))
+     Some x <- return (mkNatRepr x0)
+     return $
+       case testLeq (incNat x) n of
+         Just LeqProof -> mkFin x
+         Nothing -> error "Impossible"
+
+finTests :: IO TestTree
+finTests =
+  testGroup "Fin" <$>
+    return
+      [ testCase "minBound <= maxBound (1)" $
+          assertBool
+            "minBound <= maxBound (1)"
+            ((minBound :: Fin 1) <= (minBound :: Fin 1))
+      , testCase "minBound <= maxBound (2)" $
+          assertBool
+            "minBound <= maxBound (2)"
+            ((minBound :: Fin 2) <= (minBound :: Fin 2))
+
+#if __GLASGOW_HASKELL__ >= 806
+      , testCase "Eq-Fin-laws-1" $
+          assertBool "Eq-Fin-laws-1" =<<
+            HC.lawsCheck (HC.eqLaws (genFin (knownNat @1)))
+
+      , testCase "Ord-Fin-laws-1" $
+          assertBool "Ord-Fin-laws-1" =<<
+            HC.lawsCheck (HC.ordLaws (genFin (knownNat @1)))
+
+      , testCase "Eq-Fin-laws-10" $
+          assertBool "Eq-Fin-laws-10" =<<
+            HC.lawsCheck (HC.eqLaws (genFin (knownNat @10)))
+
+      , testCase "Ord-Fin-laws-10" $
+          assertBool "Ord-Fin-laws-10" =<<
+            HC.lawsCheck (HC.ordLaws (genFin (knownNat @10)))
+#endif
+      ]

--- a/test/UnitTest.hs
+++ b/test/UnitTest.hs
@@ -3,6 +3,7 @@ import Test.Tasty.Ingredients
 import Test.Tasty.Runners.AntXML
 
 import qualified Test.Context
+import qualified Test.Fin
 import qualified Test.List
 import qualified Test.NatRepr
 import qualified Test.SymbolRepr
@@ -23,6 +24,7 @@ tests :: IO TestTree
 tests = testGroup "ParameterizedUtils" <$> sequence
   [ Test.Context.contextTests
   , pure Test.List.tests
+  , Test.Fin.finTests
   , Test.NatRepr.natTests
   , Test.SymbolRepr.symbolTests
   , Test.TH.thTests


### PR DESCRIPTION
The type 'VectorIndex' was named something more specific than it needed to be. Another way to look at it is that it's the definition of the family of finite types.