### PR TITLE
Allow building with `hashable-1.4.*`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog for the `parameterized-utils` package
 
+## next -- *TBA*
+
+  * Allow building with `hashable-1.4.*`. Because `hashable-1.4.0.0` adds an
+    `Eq` superclass to `Hashable`, some instances of `Hashable` in
+    `parameterized-utils` now require additional `TestEquality` constraints, as
+    the corresponding `Eq` instances for these data types also require
+    `TestEquality` constraints.
+
 ## 2.1.5.0 -- *2022 Mar 08*
 
   * Add support for GHC 9.2.  Drop support for GHC 8.4 (or earlier).

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -56,8 +56,8 @@ library
                , containers
                , deepseq
                , ghc-prim
-               , hashable       >=1.2  && <1.4
-               , hashtables     ==1.2.*
+               , hashable       >=1.2  && <1.5
+               , hashtables     >=1.2  && <1.4
                , indexed-traversable
                , lens           >=4.16 && <5.2
                , mtl

--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -351,7 +351,7 @@ instance OrdF f => Ord (TypeAp f tp) where
 instance ShowF f => Show (TypeAp f tp) where
   showsPrec p (TypeAp x) = showsPrecF p x
 
-instance HashableF f => Hashable (TypeAp f tp) where
+instance (HashableF f, TestEquality f) => Hashable (TypeAp f tp) where
   hashWithSalt s (TypeAp x) = hashWithSaltF s x
 
 ------------------------------------------------------------------------

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -595,10 +595,10 @@ instance Hashable (Index ctx tp) where
 instance HashableF (Index ctx) where
   hashWithSaltF s i = hashWithSalt s (indexVal i)
 
-instance HashableF f => HashableF (Assignment f) where
+instance (HashableF f, TestEquality f) => HashableF (Assignment f) where
   hashWithSaltF = hashWithSalt
 
-instance HashableF f => Hashable (Assignment f ctx) where
+instance (HashableF f, TestEquality f) => Hashable (Assignment f ctx) where
   hashWithSalt s AssignmentEmpty = s
   hashWithSalt s (AssignmentExtend asgn x) = (s `hashWithSalt` asgn) `hashWithSaltF` x
 

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -851,10 +851,10 @@ instance HashableF (Index ctx) where
 instance Hashable (Index ctx tp) where
   hashWithSalt = hashWithSaltF
 
-instance HashableF f => Hashable (Assignment f ctx) where
+instance (HashableF f, TestEquality f) => Hashable (Assignment f ctx) where
   hashWithSalt s (Assignment a) = hashWithSaltF s a
 
-instance HashableF f => HashableF (Assignment f) where
+instance (HashableF f, TestEquality f) => HashableF (Assignment f) where
   hashWithSaltF = hashWithSalt
 
 instance ShowF f => Show (Assignment f ctx) where

--- a/src/Data/Parameterized/Some.hs
+++ b/src/Data/Parameterized/Some.hs
@@ -33,7 +33,7 @@ instance TestEquality f => Eq (Some f) where
 instance OrdF f => Ord (Some f) where
   compare (Some x) (Some y) = toOrdering (compareF x y)
 
-instance HashableF f => Hashable (Some f) where
+instance (HashableF f, TestEquality f) => Hashable (Some f) where
   hashWithSalt s (Some x) = hashWithSaltF s x
   hash (Some x) = hashF x
 


### PR DESCRIPTION
Because `hashable-1.4.0.0` adds an `Eq` superclass to `Hashable`, several `Hashable` instances in `parameterized-utils` now must add additional constraints to satisfy the corresponding `Eq` instances. For instance, several `Eq` instances have `TestEquality` constraints, so the `Hashable` instances must have corresponding `TestEquality` constraints as well.

Fixes #126.