### PR TITLE
Support building with GHC 9.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [9.2.1, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4]
+        ghc: [9.2.1, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -47,7 +47,6 @@ jobs:
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           echo GHC=$GHC >> $GITHUB_ENV
           case ${{ matrix.ghc }} in
-            8.4.4) GHC_NIXPKGS=github:nixos/nixpkgs/20.03 ;;
             8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
             9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
             9.2.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [9.0.1, 8.10.4, 8.8.4, 8.6.5, 8.4.4]
+        ghc: [9.2.1, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4]
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -20,18 +20,11 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           enable-stack: false
-      - uses: cachix/install-nix-action@v12
-        if: ${{ matrix.ghc == '8.4.4' }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
         with:
-          nix_path: nixpkgs=channel:nixos-20.03
-      - uses: cachix/install-nix-action@v12
-        if: ${{ matrix.ghc == '9.0.1' }}
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/install-nix-action@v12
-        if: ${{ matrix.ghc != '8.4.4' && matrix.ghc != '9.0.1' }}
-        with:
-          nix_path: nixpkgs=channel:nixos-20.09
+          nix_path: nixpkgs=channel:nixos-21.11
+          install_url: https://releases.nixos.org/nix/nix-2.4/install
       - uses: actions/cache@v2
         name: Cache builds
         with:
@@ -48,9 +41,19 @@ jobs:
         shell: bash
         run: cabal update
       - name: Setup Environment Vars
+        # Setup a nix shell environment command that will supply the
+        # appropriate GHC version
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           echo GHC=$GHC >> $GITHUB_ENV
+          case ${{ matrix.ghc }} in
+            8.4.4) GHC_NIXPKGS=github:nixos/nixpkgs/20.03 ;;
+            8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
+            9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
+            9.2.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
+            *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
+          esac
+          echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV
       - name: Package's Cabal/GHC compatibility
         shell: bash
         # Using setup will use the cabal library installed with GHC
@@ -63,7 +66,7 @@ jobs:
           defsetup()  { echo import Distribution.Simple; echo main = defaultMain; }
           setup_src() { if [ ! -f Setup.hs ] ; then defsetup > DefSetup.hs; fi; ls *Setup.hs; }
           setup_bin() { echo setup.${{ matrix.ghc }}; }
-          with_ghc()  { nix-shell -p $GHC --run "$(echo ${@})"; }
+          with_ghc()  { $NS -c ${@}; }
           with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean
       - name: Cabal check
         shell: bash

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Changelog for the `parameterized-utils` package
 
+## next -- *TBA*
+
+  * Add support for GHC 9.2.
+  * Add a `Data.Parameterized.NatRepr.leqZero :: LeqProof 0 n` function.
+    Starting with GHC 9.2, GHC is no longer able to conclude that
+    `forall (n :: Nat). 0 <= n` due to changes in how the `(<=)` type family
+    works. As a result, this fact must be asserted as an axiom, which the
+    `leqZero` function accomplishes.
+
 ## 2.1.4.0 -- *2021 Oct 1*
 
   * Added the `ifoldLM` and `fromSomeList`, `fromListWith`, and

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -19,7 +19,7 @@ Description:
 extra-source-files: Changelog.md
 homepage:      https://github.com/GaloisInc/parameterized-utils
 bug-reports:   https://github.com/GaloisInc/parameterized-utils/issues
-tested-with:   GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1
+tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1
 
 -- Many (but not all, sadly) uses of unsafe operations are
 -- controlled by this compile flag.  When this flag is set

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -59,7 +59,7 @@ library
                , hashable       >=1.2  && <1.4
                , hashtables     ==1.2.*
                , indexed-traversable
-               , lens           >=4.16 && <5.1
+               , lens           >=4.16 && <5.2
                , mtl
                , profunctors    >=5.6 && < 5.7
                , template-haskell

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -19,7 +19,7 @@ Description:
 extra-source-files: Changelog.md
 homepage:      https://github.com/GaloisInc/parameterized-utils
 bug-reports:   https://github.com/GaloisInc/parameterized-utils/issues
-tested-with:   GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.1
+tested-with:   GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1
 
 -- Many (but not all, sadly) uses of unsafe operations are
 -- controlled by this compile flag.  When this flag is set

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE GADTs #-}

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -87,6 +87,7 @@ module Data.Parameterized.NatRepr
   , testStrictLeq
   , leqRefl
   , leqTrans
+  , leqZero
   , leqAdd2
   , leqSub2
   , leqMulCongr
@@ -347,7 +348,7 @@ withSubMulDistribRight _n _m _p f =
 
 -- | @LeqProof m n@ is a type whose values are only inhabited when @m@
 -- is less than or equal to @n@.
-data LeqProof m n where
+data LeqProof (m :: Nat) (n :: Nat) where
   LeqProof :: (m <= n) => LeqProof m n
 
 -- | (<=) is a decidable relation on nats.
@@ -427,6 +428,10 @@ leqTrans :: LeqProof m n -> LeqProof n p -> LeqProof m p
 leqTrans LeqProof LeqProof = unsafeCoerce (LeqProof :: LeqProof 0 0)
 {-# NOINLINE leqTrans #-}
 
+-- | Zero is less than or equal to any 'Nat'.
+leqZero :: LeqProof 0 n
+leqZero = unsafeCoerce (LeqProof :: LeqProof 0 0)
+
 -- | Add both sides of two inequalities
 leqAdd2 :: LeqProof x_l x_h -> LeqProof y_l y_h -> LeqProof (x_l + y_l) (x_h + y_h)
 leqAdd2 x y = seq x $ seq y $ unsafeCoerce (LeqProof :: LeqProof 0 0)
@@ -476,14 +481,14 @@ leqMulMono x y = leqMulCongr (leqProof (Proxy :: Proxy 1) x) (leqRefl y)
 -- | Produce proof that adding a value to the larger element in an LeqProof
 -- is larger
 leqAdd :: forall f m n p . LeqProof m n -> f p -> LeqProof m (n+p)
-leqAdd x _ = leqAdd2 x (LeqProof :: LeqProof 0 p)
+leqAdd x _ = leqAdd2 x (leqZero @p)
 
 leqAddPos :: (1 <= m, 1 <= n) => p m -> q n -> LeqProof 1 (m + n)
 leqAddPos m n = leqAdd (leqProof (Proxy :: Proxy 1) m) n
 
 -- | Produce proof that subtracting a value from the smaller element is smaller.
 leqSub :: forall m n p . LeqProof m n -> LeqProof p m -> LeqProof (m-p) n
-leqSub x _ = leqSub2 x (LeqProof :: LeqProof 0 p)
+leqSub x _ = leqSub2 x (leqZero @p)
 
 addIsLeq :: f n -> g m -> LeqProof n (n + m)
 addIsLeq n m = leqAdd (leqRefl n) m

--- a/src/Data/Parameterized/NatRepr/Internal.hs
+++ b/src/Data/Parameterized/NatRepr/Internal.hs
@@ -24,7 +24,7 @@ module Data.Parameterized.NatRepr.Internal where
 import Data.Data
 import Data.Hashable
 import GHC.TypeNats
-import Numeric.Natural
+import qualified Numeric.Natural as Natural
 import Unsafe.Coerce
 
 import Data.Parameterized.Axiom
@@ -38,7 +38,7 @@ import Data.Parameterized.DecidableEq
 --
 -- This can be used for performing dynamic checks on a type-level natural
 -- numbers.
-newtype NatRepr (n::Nat) = NatRepr { natValue :: Natural
+newtype NatRepr (n::Nat) = NatRepr { natValue :: Natural.Natural
                                      -- ^ The underlying natural value of the number.
                                    }
   deriving (Hashable, Data)

--- a/src/Data/Parameterized/Vector.hs
+++ b/src/Data/Parameterized/Vector.hs
@@ -501,7 +501,10 @@ unfoldrWithIndexM' h gen start =
         snd <$> getCompose3 (natRecBounded (decNat h) (decNat h) base step)
       }
   where base :: Compose3 m ((,) b) (Vector' a) 0
-        base = Compose3 $ (\(hd, b) -> (b, MkVector' (singleton hd))) <$> gen (knownNat @0) start
+        base =
+          case leqZero @h of { LeqProof ->
+          Compose3 $ (\(hd, b) -> (b, MkVector' (singleton hd))) <$> gen (knownNat @0) start
+          }
         step :: forall p. (1 <= h, p <= h - 1)
              => NatRepr p
              -> Compose3 m ((,) b) (Vector' a) p

--- a/test/Test/Vector.hs
+++ b/test/Test/Vector.hs
@@ -29,7 +29,7 @@ import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some
 import           Data.Parameterized.Vector
 import           Data.Semigroup
-import           GHC.TypeLits
+import           GHC.TypeLits (KnownNat)
 import           Hedgehog
 import qualified Hedgehog.Gen as HG
 import           Hedgehog.Range


### PR DESCRIPTION
This contains a variety of changes needed to make `parameterized-utils` compile
with GHC 9.2:

* In `base-4.16.*`, the internals of the `(<=)` type family in `GHC.TypeNats` have changed (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=7e2ce63ba042c1934654c4316dc02028d8d3dd31#changes-to-the-and-type-families)). As a result, GHC is no longer able to infer `0 <= n` for all `n :: Nat`, as this fact must now be assumed as an axiom. This prevents a handful of functions in `Data.Parameterized.NatRepr` and `Data.Parameterized.Vector` from compiling, as they relied on `0 <= n` to typecheck.

  I resolved this issue by introducing a new `leqZero :: LeqProof 0 n` function to `Data.Parameterized.NatRepr` and using it where needed.
* In `template-haskell-2.18.*`, the type of `ConP` gained an additional field (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=7e2ce63ba042c1934654c4316dc02028d8d3dd31#template-haskell-218)). As a result, I needed to use some CPP in `Data.Parameterized.TH.GADT` to make the two uses of `ConP` compile. To minimize the amount of CPP that I needed, I factored out this logic into a `conPCompat` function.
* In GHC 9.2, enabling `UndecidableInstances` no longer implies enabling `FlexibleContexts` (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=7e2ce63ba042c1934654c4316dc02028d8d3dd31#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations)). As a result, I had to enable `FlexibleContexts` in `Data.Parameterized.Context.Unsafe`.
* The upper version bounds on `lens` have been raised to allow building with `lens-5.1`, which is the minimum version of `lens` that builds with GHC 9.2.