### PR TITLE
Replace `testProperty` with `testPropertyNamed`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [9.2.1, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc: [9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -49,7 +49,7 @@ jobs:
           case ${{ matrix.ghc }} in
             8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
             9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
-            9.2.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
+            9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -138,7 +138,7 @@ test-suite parameterizedTests
                , tasty >= 1.2 && < 1.5
                , tasty-ant-xml == 1.1.*
                , tasty-hunit >= 0.9 && < 0.11
-               , tasty-hedgehog
+               , tasty-hedgehog >= 1.2
 
   if impl(ghc >= 8.6)
     build-depends:

--- a/test/Test/Context.hs
+++ b/test/Test/Context.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -408,50 +409,50 @@ prop_itraverseFCTraverseFC = property $
 
 contextTests :: IO TestTree
 contextTests = testGroup "Context" <$> return
-   [ testProperty "size (unsafe)" prop_sizeUnsafe
-   , testProperty "size (safe)" prop_sizeSafe
+   [ testPropertyNamed "size (unsafe)" "prop_sizeUnsafe" prop_sizeUnsafe
+   , testPropertyNamed "size (safe)" "prop_sizeSafe" prop_sizeSafe
 
-   , testProperty "safe_index_eq" prop_safeIndexEq
+   , testPropertyNamed "safe_index_eq" "prop_safeIndexEq" prop_safeIndexEq
 
-   , testProperty "unsafe_index_eq" prop_unsafeIndexEq
+   , testPropertyNamed "unsafe_index_eq" "prop_unsafeIndexEq" prop_unsafeIndexEq
 
-   , testProperty "safe_tolist" prop_safeToList
-   , testProperty "unsafe_tolist" prop_unsafeToList
+   , testPropertyNamed "safe_tolist" "prop_safeToList" prop_safeToList
+   , testPropertyNamed "unsafe_tolist" "prop_unsafeToList" prop_unsafeToList
 
-   , testProperty "adjust test monadic" prop_adjustTestMonadic
+   , testPropertyNamed "adjust test monadic" "prop_adjustTestMonadic" prop_adjustTestMonadic
 
-   , testProperty "adjust test" prop_adjustTest
+   , testPropertyNamed "adjust test" "prop_adjustTest" prop_adjustTest
 
-   , testProperty "update test" prop_updateTest
+   , testPropertyNamed "update test" "prop_updateTest" prop_updateTest
 
-   , testProperty "safe_eq" prop_safeEq
-   , testProperty "unsafe_eq" prop_unsafeEq
+   , testPropertyNamed "safe_eq" "prop_safeEq" prop_safeEq
+   , testPropertyNamed "unsafe_eq" "prop_unsafeEq" prop_unsafeEq
 
-   , testProperty "take none" prop_takeNone
-   , testProperty "drop none" prop_dropNone
+   , testPropertyNamed "take none" "prop_takeNone" prop_takeNone
+   , testPropertyNamed "drop none" "prop_dropNone" prop_dropNone
 
-   , testProperty "take all" prop_takeAll
-   , testProperty "drop all" prop_dropAll
+   , testPropertyNamed "take all" "prop_takeAll" prop_takeAll
+   , testPropertyNamed "drop all" "prop_dropAll" prop_dropAll
 
-   , testProperty "append_take" prop_appendTake
+   , testPropertyNamed "append_take" "prop_appendTake" prop_appendTake
 
-   , testProperty "append_take_drop" prop_appendTakeDrop
+   , testPropertyNamed "append_take_drop" "prop_appendTakeDrop" prop_appendTakeDrop
 
-   , testProperty "append_take_drop_multiple" prop_appendTakeDropMultiple
+   , testPropertyNamed "append_take_drop_multiple" "prop_appendTakeDropMultiple" prop_appendTakeDropMultiple
 
-   , testProperty "zip/unzip" prop_zipUnzip
+   , testPropertyNamed "zip/unzip" "prop_zipUnzip" prop_zipUnzip
 
-   , testProperty "fmapFC_identity" prop_fmapFCIdentity
+   , testPropertyNamed "fmapFC_identity" "prop_fmapFCIdentity" prop_fmapFCIdentity
 
-   , testProperty "fmapFC_assoc" prop_fmapFCAssoc
+   , testPropertyNamed "fmapFC_assoc" "prop_fmapFCAssoc" prop_fmapFCAssoc
 
-   , testProperty "imapFC_index_noop" prop_imapFCIndexNoop
+   , testPropertyNamed "imapFC_index_noop" "prop_imapFCIndexNoop" prop_imapFCIndexNoop
 
-   , testProperty "imapFC/fmapFC" prop_imapFCFmapFC
+   , testPropertyNamed "imapFC/fmapFC" "prop_imapFCFmapFC" prop_imapFCFmapFC
 
-   , testProperty "ifoldMapFC/foldMapFC" prop_ifoldMapFCFoldMapFC
+   , testPropertyNamed "ifoldMapFC/foldMapFC" "prop_ifoldMapFCFoldMapFC" prop_ifoldMapFCFoldMapFC
 
-   , testProperty "itraverseFC/traverseFC" prop_itraverseFCTraverseFC
+   , testPropertyNamed "itraverseFC/traverseFC" "prop_itraverseFCTraverseFC" prop_itraverseFCTraverseFC
 
    , testCaseSteps "explicit indexing (unsafe)" $ \step -> do
        let mkUPayload :: U.Assignment Payload TestCtx

--- a/test/Test/NatRepr.hs
+++ b/test/Test/NatRepr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Test.NatRepr
   ( natTests
   )
@@ -22,5 +23,5 @@ prop_withKnownNat = property $
 
 natTests :: IO TestTree
 natTests = testGroup "Nat" <$> return
-  [ testProperty "withKnownNat" prop_withKnownNat
+  [ testPropertyNamed "withKnownNat" "prop_withKnownNat" prop_withKnownNat
   ]

--- a/test/Test/NatRepr.hs
+++ b/test/Test/NatRepr.hs
@@ -13,11 +13,14 @@ import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some
 import           GHC.TypeLits
 
+prop_withKnownNat :: Property
+prop_withKnownNat = property $
+  do nInt <- forAll $ HG.int (linearBounded :: Range Int)
+     case someNat nInt of
+       Nothing       -> diff nInt (<) 0
+       Just (Some r) -> nInt === withKnownNat r (fromEnum $ natVal r)
+
 natTests :: IO TestTree
 natTests = testGroup "Nat" <$> return
-  [ testProperty "withKnownNat" $ property $ do
-      nInt <- forAll $ HG.int (linearBounded :: Range Int)
-      case someNat nInt of
-        Nothing       -> diff nInt (<) 0
-        Just (Some r) -> nInt === withKnownNat r (fromEnum $ natVal r)
+  [ testProperty "withKnownNat" prop_withKnownNat
   ]

--- a/test/Test/Vector.hs
+++ b/test/Test/Vector.hs
@@ -5,6 +5,7 @@
 {-# Language ExplicitForAll #-}
 {-# Language FlexibleInstances #-}
 {-# Language LambdaCase #-}
+{-# Language OverloadedStrings #-}
 {-# Language ScopedTypeVariables #-}
 {-# Language StandaloneDeriving #-}
 {-# Language TypeFamilies #-}
@@ -249,51 +250,51 @@ prop_OrdEqVectorIndex = property $
 -- We use @Ordering@ just because it's simple
 vecTests :: IO TestTree
 vecTests = testGroup "Vector" <$> return
-  [ testProperty "reverse100" prop_reverse100
-  , testProperty "reverseSingleton" prop_reverseSingleton
+  [ testPropertyNamed "reverse100" "prop_reverse100" prop_reverse100
+  , testPropertyNamed "reverseSingleton" "prop_reverseSingleton" prop_reverseSingleton
 
-  , testProperty "split-join" prop_splitJoin
+  , testPropertyNamed "split-join" "prop_splitJoin" prop_splitJoin
 
   -- @cons@ is the same for vectors or lists
-  , testProperty "cons" prop_cons
+  , testPropertyNamed "cons" "prop_cons" prop_cons
 
   -- @snoc@ is like appending to a list
-  , testProperty "snoc" prop_snoc
+  , testPropertyNamed "snoc" "prop_snoc" prop_snoc
 
   -- @snoc@ and @unsnoc@ are inverses
-  , testProperty "snoc/unsnoc" prop_snocUnsnoc
+  , testPropertyNamed "snoc/unsnoc" "prop_snocUnsnoc" prop_snocUnsnoc
 
   -- @generate@ is like mapping a function over indices
-  , testProperty "generate" prop_generate
+  , testPropertyNamed "generate" "prop_generate" prop_generate
 
   -- @unfold@ works like @unfold@ on lists
-  , testProperty "unfold" prop_unfold
+  , testPropertyNamed "unfold" "prop_unfold" prop_unfold
 
   -- Converting to and from assignments preserves size and last element
-  , testProperty "to-from-assignment" prop_toFromAssignment
+  , testPropertyNamed "to-from-assignment" "prop_toFromAssignment" prop_toFromAssignment
 
   -- NOTE: We don't use hedgehog-classes here, because the way the types work
   -- would require this to only tests vectors of some fixed size.
   --
   -- Also, for 'fmap-compose', hedgehog-classes only tests two fixed functions
   -- over integers.
-  , testProperty "fmap-id" prop_fmapId
+  , testPropertyNamed "fmap-id" "prop_fmapId" prop_fmapId
 
-  , testProperty "fmap-compose" prop_fmapCompose
+  , testPropertyNamed "fmap-compose" "prop_fmapCompose" prop_fmapCompose
 
-  , testProperty "iterateN-range" prop_iterateNRange
+  , testPropertyNamed "iterateN-range" "prop_iterateNRange" prop_iterateNRange
 
-  , testProperty "indicesOf-range" prop_indicesOfRange
+  , testPropertyNamed "indicesOf-range" "prop_indicesOfRange" prop_indicesOfRange
 
-  , testProperty "imap-const" prop_imapConst
+  , testPropertyNamed "imap-const" "prop_imapConst" prop_imapConst
 
-  , testProperty "ifoldMap-const" prop_ifoldMapConst
+  , testPropertyNamed "ifoldMap-const" "prop_ifoldMapConst" prop_ifoldMapConst
 
-  , testProperty "imap-const-indicesOf" prop_imapConstIndicesOf
+  , testPropertyNamed "imap-const-indicesOf" "prop_imapConstIndicesOf" prop_imapConstIndicesOf
 
-  , testProperty "imap-elemAt" prop_imapElemAt
+  , testPropertyNamed "imap-elemAt" "prop_imapElemAt" prop_imapElemAt
 
-  , testProperty "Ord-Eq-VectorIndex" prop_OrdEqVectorIndex
+  , testPropertyNamed "Ord-Eq-VectorIndex" "prop_OrdEqVectorIndex" prop_OrdEqVectorIndex
 
 #if __GLASGOW_HASKELL__ >= 806
   -- Test a few different sizes since the types force each test to use a


### PR DESCRIPTION
`tasty-hedgehog-1.2.0.0` has deprecated the [`testProperty`](https://hackage.haskell.org/package/tasty-hedgehog-1.2.0.0/docs/Test-Tasty-Hedgehog.html#v:testProperty) function in favor of [`testPropertyNamed`](https://hackage.haskell.org/package/tasty-hedgehog-1.2.0.0/docs/Test-Tasty-Hedgehog.html#v:testPropertyNamed), which expects the name of the `Property` value being tested as an argument. To avoid heaps of deprecation warnings when building the test suite, let's switch from `testProperty` to `testPropertyNamed`.