### PR TITLE
Draft: Redefines the EqF type class to be heterogeneous.

### DIFF
--- a/src/Data/Parameterized/All.hs
+++ b/src/Data/Parameterized/All.hs
@@ -63,7 +63,7 @@ instance ShowF f => Show (All f) where
   show (All fa) = showF fa
 
 instance EqF f => Eq (All f) where
-  (All x) == (All y) = eqF x y
+  All x == All y = isJust (x `eqF` y)
 
 allConst :: a -> All (Const a)
 allConst a = All (Const a)

--- a/src/Data/Parameterized/BoolRepr.hs
+++ b/src/Data/Parameterized/BoolRepr.hs
@@ -79,6 +79,9 @@ instance TestEquality BoolRepr where
   testEquality FalseRepr FalseRepr = Just Refl
   testEquality _ _ = Nothing
 
+instance EqF BoolRepr where
+  eqF = testEquality
+
 instance DecidableEq BoolRepr where
   decEq TrueRepr  TrueRepr  = Left Refl
   decEq FalseRepr FalseRepr = Left Refl

--- a/src/Data/Parameterized/Context.hs
+++ b/src/Data/Parameterized/Context.hs
@@ -168,7 +168,7 @@ toVector a f = V.create $ do
 --   `prefix` as a prefix, and computing the tail of xs
 --   not in the prefix, if so.
 dropPrefix :: forall f xs prefix a.
-  TestEquality f =>
+  EqF f =>
   Assignment f xs     {- ^ Assignment to split -} ->
   Assignment f prefix {- ^ Expected prefix -} ->
   a {- ^ error continuation -} ->
@@ -189,7 +189,7 @@ dropPrefix xs0 prefix err = go xs0 (sizeInt (size xs0))
     go xs' (sz_x-1) (\zs -> success (zs :> z))
 
   go xs _ success =
-    case testEquality xs prefix of
+    case eqF xs prefix of
       Just Refl -> success Empty
       Nothing   -> err
 

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -290,6 +290,9 @@ instance TestEquality (Index ctx) where
          Just Refl -> Just Refl
          Nothing -> Nothing
 
+instance EqF (Index ctx) where
+  eqF = testEquality
+
 instance Ord (Index ctx tp) where
   compare i j = toOrdering (compareF i j)
 
@@ -543,8 +546,8 @@ idxlookup _ AssignmentEmpty idx = case idx of {}
 (!^) :: KnownDiff l r => Assignment f r -> Index l tp -> f tp
 a !^ i = a ! extendIndex i
 
-instance TestEquality f => Eq (Assignment f ctx) where
-  x == y = isJust (testEquality x y)
+instance EqF f => Eq (Assignment f ctx) where
+  x == y = isJust (eqF x y)
 
 testEq :: (forall x y. f x -> f y -> Maybe (x :~: y))
        -> Assignment f cxt1 -> Assignment f cxt2 -> Maybe (cxt1 :~: cxt2)
@@ -563,8 +566,10 @@ instance TestEqualityFC Assignment where
    testEqualityFC f = testEq f
 instance TestEquality f => TestEquality (Assignment f) where
    testEquality x y = testEq testEquality x y
-instance TestEquality f => PolyEq (Assignment f x) (Assignment f y) where
-  polyEqF x y = fmap (\Refl -> Refl) $ testEquality x y
+instance EqF f => PolyEq (Assignment f x) (Assignment f y) where
+  polyEqF x y = fmap (\Refl -> Refl) $ eqF x y
+instance EqF f => EqF (Assignment f) where
+  eqF x y = testEq eqF x y
 
 compareAsgn :: (forall x y. f x -> f y -> OrderingF x y)
             -> Assignment f ctx1 -> Assignment f ctx2 -> OrderingF ctx1 ctx2

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -246,8 +246,8 @@ type role Index nominal nominal
 instance Eq (Index ctx tp) where
   Index i == Index j = i == j
 
-instance TestEquality (Index ctx) where
-  testEquality (Index i) (Index j)
+instance EqF (Index ctx) where
+  eqF (Index i) (Index j)
     | i == j = Just unsafeAxiom
     | otherwise = Nothing
 
@@ -832,8 +832,11 @@ instance TestEqualityFC Assignment where
 instance TestEquality f => TestEquality (Assignment f) where
   testEquality = testEqualityFC testEquality
 
-instance TestEquality f => Eq (Assignment f ctx) where
-  x == y = isJust (testEquality x y)
+instance EqF f => Eq (Assignment f ctx) where
+  x == y = isJust (eqF x y)
+
+instance EqF f => EqF (Assignment f) where
+  eqF = testEqualityFC eqF
 
 instance OrdFC Assignment where
   compareFC test (Assignment x) (Assignment y) =

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -246,10 +246,13 @@ type role Index nominal nominal
 instance Eq (Index ctx tp) where
   Index i == Index j = i == j
 
-instance EqF (Index ctx) where
-  eqF (Index i) (Index j)
+instance TestEquality (Index ctx) where
+  testEquality (Index i) (Index j)
     | i == j = Just unsafeAxiom
     | otherwise = Nothing
+
+instance EqF (Index ctx) where
+  eqF = testEquality
 
 instance Ord (Index ctx tp) where
   Index i `compare` Index j = compare i j

--- a/src/Data/Parameterized/DataKind.hs
+++ b/src/Data/Parameterized/DataKind.hs
@@ -45,6 +45,14 @@ instance ( TestEquality f, TestEquality g ) => TestEquality (PairRepr f g) where
       , ( TH.DataArg 1 `TH.TypeApp` TH.AnyType, [|testEquality|] )
       ])
 
+instance ( EqF f, EqF g) => EqF (PairRepr f g) where
+  eqF =
+    $(TH.structuralTypeEquality [t|PairRepr|]
+      [
+        ( TH.DataArg 0 `TH.TypeApp` TH.AnyType, [|eqF|] )
+      , ( TH.DataArg 1 `TH.TypeApp` TH.AnyType, [|eqF|] )
+      ])
+
 deriving instance ( Ord (f a), Ord (g b) ) => Ord (PairRepr f g '(a, b))
 instance ( OrdF f, OrdF g ) => OrdF (PairRepr f g) where
   compareF =

--- a/src/Data/Parameterized/HashTable.hs
+++ b/src/Data/Parameterized/HashTable.hs
@@ -9,7 +9,7 @@
 --
 -- NOTE: This API makes use of 'unsafeCoerce' to implement the parameterized
 -- hashtable abstraction.  This should be type-safe provided that the
--- 'TestEquality' instance on the key type is implemented soundly.
+-- 'EqF' instance on the key type is implemented soundly.
 ------------------------------------------------------------------------
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}
@@ -53,7 +53,7 @@ newSized :: Int -> ST s (HashTable s k v)
 newSized n = HashTable <$> H.newSized n
 
 -- | Create a hash table that is a copy of the current one.
-clone :: (HashableF key, TestEquality key)
+clone :: (HashableF key, EqF key)
       => HashTable s key val
       -> ST s (HashTable s key val)
 clone (HashTable tbl) = do
@@ -65,7 +65,7 @@ clone (HashTable tbl) = do
   return $! HashTable r
 
 -- | Lookup value of key in table.
-lookup :: (HashableF key, TestEquality key)
+lookup :: (HashableF key, EqF key)
        => HashTable s key val
        -> key tp
        -> ST s (Maybe (val tp))
@@ -73,7 +73,7 @@ lookup (HashTable h) k = fmap unsafeCoerce <$> H.lookup h (Some k)
 {-# INLINE lookup #-}
 
 -- | Insert new key and value mapping into table.
-insert :: (HashableF key, TestEquality key)
+insert :: (HashableF key, EqF key)
        => HashTable s (key :: k -> Type) (val :: k -> Type)
        -> key tp
        -> val tp
@@ -81,19 +81,19 @@ insert :: (HashableF key, TestEquality key)
 insert (HashTable h) k v = H.insert h (Some k) (unsafeCoerce v)
 
 -- | Return true if the key is in the hash table.
-member :: (HashableF key, TestEquality key)
+member :: (HashableF key, EqF key)
        => HashTable s (key :: k -> Type) (val :: k -> Type)
        -> key (tp :: k)
        -> ST s Bool
 member (HashTable h) k = isJust <$> H.lookup h (Some k)
 
 -- | Delete an element from the hash table.
-delete :: (HashableF key, TestEquality key)
+delete :: (HashableF key, EqF key)
        => HashTable s (key :: k -> Type) (val :: k -> Type)
        -> key (tp :: k)
        -> ST s ()
 delete (HashTable h) k = H.delete h (Some k)
 
-clear :: (HashableF key, TestEquality key)
+clear :: (HashableF key, EqF key)
       => HashTable s (key :: k -> Type) (val :: k -> Type) -> ST s ()
 clear (HashTable h) = H.mapM_ (\(k,_) -> H.delete h k) h

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -214,6 +214,14 @@ instance TestEquality f => TestEquality (List f) where
     pure Refl
   testEquality _ _ = Nothing
 
+instance EqF f => EqF (List f) where
+  eqF Nil Nil = Just Refl
+  eqF (xh :< xl) (yh :< yl) = do
+    Refl <- eqF xh yh
+    Refl <- eqF xl yl
+    pure Refl
+  eqF _ _ = Nothing
+
 instance OrdF f => OrdF (List f) where
   compareF Nil Nil = EQF
   compareF Nil _ = LTF
@@ -267,10 +275,10 @@ deriving instance Show  (Index l x)
 
 instance ShowF (Index l)
 
-instance TestEquality (Index l) where
-  testEquality IndexHere IndexHere = Just Refl
-  testEquality (IndexThere x) (IndexThere y) = testEquality x y
-  testEquality _ _ = Nothing
+instance EqF (Index l) where
+  eqF IndexHere IndexHere = Just Refl
+  eqF (IndexThere x) (IndexThere y) = eqF x y
+  eqF _ _ = Nothing
 
 instance OrdF (Index l) where
   compareF IndexHere IndexHere = EQF

--- a/src/Data/Parameterized/Map.hs
+++ b/src/Data/Parameterized/Map.hs
@@ -151,7 +151,7 @@ instance Bin.IsBinTree (MapF k a) (Pair k a) where
   size Tip              = 0
   size (Bin sz _ _ _ _) = sz
 
-instance (TestEquality k, EqF a) => Eq (MapF k a) where
+instance (EqF k, EqF a) => Eq (MapF k a) where
   x == y = size x == size y && toList x == toList y
 
 ------------------------------------------------------------------------

--- a/src/Data/Parameterized/NatRepr/Internal.hs
+++ b/src/Data/Parameterized/NatRepr/Internal.hs
@@ -53,6 +53,9 @@ instance TestEquality NatRepr where
     | m == n = Just unsafeAxiom
     | otherwise = Nothing
 
+instance EqF NatRepr where
+  eqF = testEquality
+
 instance DecidableEq NatRepr where
   decEq (NatRepr m) (NatRepr n)
     | m == n    = Left unsafeAxiom

--- a/src/Data/Parameterized/Nonce.hs
+++ b/src/Data/Parameterized/Nonce.hs
@@ -132,6 +132,9 @@ instance TestEquality (Nonce s) where
   testEquality x y | indexValue x == indexValue y = Just unsafeAxiom
                    | otherwise = Nothing
 
+instance EqF (Nonce s) where
+  eqF = testEquality
+
 instance OrdF (Nonce s) where
   compareF x y =
     case compare (indexValue x) (indexValue y) of

--- a/src/Data/Parameterized/Nonce/Unsafe.hs
+++ b/src/Data/Parameterized/Nonce/Unsafe.hs
@@ -68,6 +68,9 @@ instance TestEquality Nonce where
   testEquality x y | indexValue x == indexValue y = Just unsafeAxiom
                    | otherwise = Nothing
 
+instance EqF Nonce where
+  eqF = testEquality
+
 instance OrdF Nonce where
   compareF x y =
     case compare (indexValue x) (indexValue y) of

--- a/src/Data/Parameterized/Pair.hs
+++ b/src/Data/Parameterized/Pair.hs
@@ -27,10 +27,12 @@ import Data.Parameterized.TraversableF
 data Pair (a :: k -> Type) (b :: k -> Type) where
   Pair :: !(a tp) -> !(b tp) -> Pair a b
 
-instance (TestEquality a, EqF b) => Eq (Pair a b) where
+instance (EqF a, EqF b) => Eq (Pair a b) where
   Pair xa xb == Pair ya yb =
-    case testEquality xa ya of
-      Just Refl -> eqF xb yb
+    case xa `eqF` ya of
+      Just Refl -> case xb `eqF` yb of
+        Just Refl -> True
+        Nothing -> False
       Nothing -> False
 
 instance FunctorF (Pair a) where

--- a/src/Data/Parameterized/Peano.hs
+++ b/src/Data/Parameterized/Peano.hs
@@ -233,6 +233,9 @@ instance TestEquality PeanoRepr where
 
 #endif
 
+instance EqF PeanoRepr where
+  eqF = testEquality
+
 instance DecidableEq PeanoRepr where
 #ifdef UNSAFE_OPS
   decEq (PeanoRepr m) (PeanoRepr n)

--- a/src/Data/Parameterized/Some.hs
+++ b/src/Data/Parameterized/Some.hs
@@ -27,8 +27,8 @@ import Data.Parameterized.TraversableF
 
 data Some (f:: k -> Type) = forall x . Some (f x)
 
-instance TestEquality f => Eq (Some f) where
-  Some x == Some y = isJust (testEquality x y)
+instance EqF f => Eq (Some f) where
+  Some x == Some y = isJust (eqF x y)
 
 instance OrdF f => Ord (Some f) where
   compare (Some x) (Some y) = toOrdering (compareF x y)

--- a/src/Data/Parameterized/SymbolRepr.hs
+++ b/src/Data/Parameterized/SymbolRepr.hs
@@ -84,6 +84,8 @@ instance TestEquality SymbolRepr where
    testEquality (SymbolRepr x :: SymbolRepr x) (SymbolRepr y)
       | x == y    = Just unsafeAxiom
       | otherwise = Nothing
+instance EqF SymbolRepr where
+  eqF = testEquality
 instance OrdF SymbolRepr where
    compareF (SymbolRepr x :: SymbolRepr x) (SymbolRepr y)
       | x <  y    = LTF


### PR DESCRIPTION
This is just a draft -- not ready for merge.

This implements a change discussed in #129. Basically, it redefines `EqF` to be same-kinded with `TestEquality`, since the homogeneous variant wasn't being used. The idea is that `EqF` asks "are the types AND values of these two things equal?" so it makes sense to define on non-singletons.

I tried to be relatively conservative here, keeping `TestEquality` instances in most cases.