### PR TITLE
Raise lower version bounds on `th-abstraction` to `>=0.4.2`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
           echo GHC=$GHC >> $GITHUB_ENV
           case ${{ matrix.ghc }} in
             8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
-            9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
-            9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
+            9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
+            9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -51,7 +51,7 @@ library
   import: bldflags
   build-depends: base >= 4.10 && < 5
                , base-orphans   >=0.8.2 && <0.9
-               , th-abstraction >=0.3  && <0.5
+               , th-abstraction >=0.4.2 && <0.5
                , constraints    >=0.10 && <0.14
                , containers
                , deepseq


### PR DESCRIPTION
`Data.Parameterized.ClassesC` relies on all of its imports being `Safe` or `Trustworthy`, but prior to `th-abstraction-0.4.2.0`, the modules in `th-abstraction` were unsafe. This unsafety can leak up to `parameterized-utils`, causing the build failure observed in #139.

The simplest fix is to require `th-abstraction-0.4.2.0` as the minimum, which this patch accomplishes. That version has been out for nearly two years, so this shouldn't cause any undue complications with downstream dependencies not supporting it.

Fixes #139.