### PR TITLE
RFC: Make `Some` into a newtype around `Some` from package `some`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,13 @@
     the corresponding `Eq` instances for these data types also require
     `TestEquality` constraints.
 
+  * Make `Some` a newtype around
+    [`Some`](https://hackage.haskell.org/package/some-1.0.4/docs/Data-Some.html#t:Some)
+    from [the `some` package](https://hackage.haskell.org/package/some-1.0.4).
+    This should improve performance, as the latter is a newtype. However, it
+    requires importing the `Some` pattern, rather than a data constructor.
+    Also adds `Semigroup` and `Monoid` instances.
+
 ## 2.1.5.0 -- *2022 Mar 08*
 
   * Add support for GHC 9.2.  Drop support for GHC 8.4 (or earlier).

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -62,6 +62,7 @@ library
                , lens           >=4.16 && <5.2
                , mtl
                , profunctors    >=5.6 && < 5.7
+               , some           >=1.0 && < 2.0
                , template-haskell
                , text
                , vector         ==0.12.*

--- a/src/Data/Parameterized/ClassesC.hs
+++ b/src/Data/Parameterized/ClassesC.hs
@@ -15,9 +15,9 @@ Note that there is still some ambiguity around naming conventions, see
 <https://github.com/GaloisInc/parameterized-utils/issues/23 issue 23>.
 -}
 
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Data.Parameterized.ClassesC
@@ -29,7 +29,7 @@ import Data.Type.Equality ((:~:)(..))
 import Data.Kind
 import Data.Maybe (isJust)
 import Data.Parameterized.Classes (OrderingF, toOrdering)
-import Data.Parameterized.Some (Some(..))
+import Data.Parameterized.Some (Some, pattern Some)
 
 class TestEqualityC (t :: (k -> Type) -> Type) where
   testEqualityC :: (forall x y. f x -> f y -> Maybe (x :~: y))

--- a/src/Data/Parameterized/FinMap/Unsafe.hs
+++ b/src/Data/Parameterized/FinMap/Unsafe.hs
@@ -8,6 +8,7 @@ See "Data.Parameterized.FinMap".
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -52,7 +53,7 @@ import           Data.Parameterized.Fin (Fin, mkFin)
 import qualified Data.Parameterized.Fin as Fin
 import           Data.Parameterized.NatRepr (LeqProof, NatRepr, type (+), type (<=))
 import qualified Data.Parameterized.NatRepr as NatRepr
-import           Data.Parameterized.Some (Some(Some))
+import           Data.Parameterized.Some (pattern Some)
 import           Data.Parameterized.Vector (Vector)
 import qualified Data.Parameterized.Vector as Vec
 

--- a/test/Test/Fin.hs
+++ b/test/Test/Fin.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# Language CPP #-}
@@ -22,7 +23,7 @@ import           Test.Tasty.HUnit (assertBool, testCase)
 
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Fin
-import           Data.Parameterized.Some (Some(Some))
+import           Data.Parameterized.Some (pattern Some)
 
 #if __GLASGOW_HASKELL__ >= 806
 import qualified Hedgehog.Classes as HC

--- a/test/Test/Some.hs
+++ b/test/Test/Some.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Test.Some
   ( someTests
@@ -13,7 +14,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertEqual, testCase)
 
 import           Data.Parameterized.Classes (ShowF)
-import           Data.Parameterized.Some (Some(Some), someLens)
+import           Data.Parameterized.Some (Some, pattern Some, someLens)
 
 data Item b where
   BoolItem :: Item Bool


### PR DESCRIPTION
The `Some` type from package `some` is a newtype, and is correspondingly more performant than our previous `data`-based encoding.

This change will require a major version bump and an easy but still mandatory migration for downstream codebases. Downstream code will either need to switch to using the eliminator (`viewSome`), or using pattern synonyms. Example migrations to use pattern synonyms can be seen in this commit.

This patch also uses `-XGeneralizedNewtypeDeriving` to derive the upstream `Semigroup` and `Monoid` instances, which are a good demonstration of the utility of sharing an implementation with a well-thought-out upstream package.

In the long run, I hope this paves the way towards #62. I'm not 100% sure this PR is the right way to go, but I realized that this was possible and thought it was worth a discussion.