### PR TITLE
Allow building with GHC 9.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc: [9.4.3, 9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -49,6 +49,7 @@ jobs:
             8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
             9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
+            9.4.3) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -19,7 +19,7 @@ Description:
 extra-source-files: Changelog.md
 homepage:      https://github.com/GaloisInc/parameterized-utils
 bug-reports:   https://github.com/GaloisInc/parameterized-utils/issues
-tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1
+tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.4.3
 
 -- Many (but not all, sadly) uses of unsafe operations are
 -- controlled by this compile flag.  When this flag is set

--- a/src/Data/Parameterized/Fin.hs
+++ b/src/Data/Parameterized/Fin.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-|
 Copyright        : (c) Galois, Inc 2021


### PR DESCRIPTION
The only change needed is to enable `UndecidableInstances` in `Data.Parameterized.Fin`, which is necessary due to GHC 9.4 being pickier about undecidable instance checking. See [this section](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4?version_id=24540b698481cf2b0bd11029b58eaddc0fbfbb31#stricter-undecidableinstances-checking) of the GHC 9.4 Migration Guide.

Fixes #141.