### PR TITLE
Mark `ClassesC` as Trustworthy

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -43,6 +43,7 @@ common bldflags
                -Werror=incomplete-patterns
                -Werror=missing-methods
                -Werror=overlapping-patterns
+               -Wno-trustworthy-safe
                -fhide-source-paths
   default-language: Haskell2010
 

--- a/src/Data/Parameterized/ClassesC.hs
+++ b/src/Data/Parameterized/ClassesC.hs
@@ -17,7 +17,7 @@ Note that there is still some ambiguity around naming conventions, see
 
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Data.Parameterized.ClassesC


### PR DESCRIPTION
For compatibility with lens < 5. Fixes #152.