### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [9.6.1, 9.4.5, 9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc: [9.8.1, 9.6.1, 9.4.5, 9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -53,6 +53,7 @@ jobs:
             9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             9.4.5) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
             9.6.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
+            9.8.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.11 ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -52,8 +52,8 @@ library
   import: bldflags
   build-depends: base >= 4.10 && < 5
                , base-orphans   >=0.8.2 && <0.10
-               , th-abstraction >=0.4.2 && <0.6
-               , constraints    >=0.10 && <0.14
+               , th-abstraction >=0.4.2 && <0.7
+               , constraints    >=0.10 && <0.15
                , containers
                , deepseq
                , ghc-prim
@@ -141,7 +141,7 @@ test-suite parameterizedTests
                , lens
                , mtl
                , parameterized-utils
-               , tasty >= 1.2 && < 1.5
+               , tasty >= 1.2 && < 1.6
                , tasty-ant-xml == 1.1.*
                , tasty-hunit >= 0.9 && < 0.11
                , tasty-hedgehog >= 1.2

--- a/test/Test/SymbolRepr.hs
+++ b/test/Test/SymbolRepr.hs
@@ -24,10 +24,8 @@ symbolTests :: IO TestTree
 symbolTests = testGroup "Symbol" <$> return
   [
     testCase "SomeSym" $ do
-      let syms = [ SomeSym (Jay "Blue")
-                 , SomeSym Dove
-                 , SomeSym Hawk
-                 ]
-      "Dove" @=? viewSomeSym symbolVal (head (tail syms))
+      "Jay"  @=? viewSomeSym symbolVal (SomeSym (Jay "Blue"))
+      "Dove" @=? viewSomeSym symbolVal (SomeSym Dove)
+      "Hawk" @=? viewSomeSym symbolVal (SomeSym Hawk)
 
   ]


### PR DESCRIPTION
This is mostly a matter of bumping upper version bounds. I needed to perform some mild refactoring in the test suite to avoid `-Wx-partial` warnings due to uses of the `head` and `tail` functions.