### PR TITLE
Allow building with `lens-5.3.*` and `hashable-1.5.*`

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -57,10 +57,10 @@ library
                , containers
                , deepseq
                , ghc-prim
-               , hashable       >=1.2  && <1.5
+               , hashable       >=1.2  && <1.6
                , hashtables     >=1.2  && <1.4
                , indexed-traversable
-               , lens           >=4.16 && <5.3
+               , lens           >=4.16 && <5.4
                , mtl
                , profunctors    >=5.6 && < 5.7
                , template-haskell


### PR DESCRIPTION
Bump upper version bounds for these packages to allow building with the latest Hackage releases.

Fixes #163.