### PR TITLE
Avoid -Wunused-imports warning with `base-4.20` (GHC 9.10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [9.8.1, 9.6.1, 9.4.5, 9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc: [9.10.1, 9.8.1, 9.6.1, 9.4.5, 9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -54,6 +54,7 @@ jobs:
             9.4.5) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
             9.6.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
             9.8.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.11 ;;
+            9.10.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for the `parameterized-utils` package
 
+## next -- *TBA*
+
+  * Add support for GHC 9.10.
+
 ## 2.1.8.0 -- *2023 Jan 15*
 
   * Add support for GHC 9.8.

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -19,7 +19,7 @@ Description:
 extra-source-files: Changelog.md
 homepage:      https://github.com/GaloisInc/parameterized-utils
 bug-reports:   https://github.com/GaloisInc/parameterized-utils/issues
-tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.4.3
+tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.2, GHC==9.4.5, GHC==9.6.1, GHC==9.8.1
 
 -- Many (but not all, sadly) uses of unsafe operations are
 -- controlled by this compile flag.  When this flag is set

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -19,7 +19,7 @@ Description:
 extra-source-files: Changelog.md
 homepage:      https://github.com/GaloisInc/parameterized-utils
 bug-reports:   https://github.com/GaloisInc/parameterized-utils/issues
-tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.2, GHC==9.4.5, GHC==9.6.1, GHC==9.8.1
+tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.2, GHC==9.4.5, GHC==9.6.1, GHC==9.8.1, GHC==9.10.1
 
 -- Many (but not all, sadly) uses of unsafe operations are
 -- controlled by this compile flag.  When this flag is set

--- a/src/Data/Parameterized/Map.hs
+++ b/src/Data/Parameterized/Map.hs
@@ -86,7 +86,7 @@ import           Control.Lens (Traversal', Lens')
 import           Control.Monad.Identity (Identity(..))
 import           Control.Monad (foldM)
 import           Data.Kind (Type)
-import           Data.List (intercalate, foldl')
+import qualified Data.List as List
 import           Data.Monoid
 import           Prelude hiding (filter, lookup, map, traverse, null)
 
@@ -370,7 +370,7 @@ showMap :: (forall tp . ktp tp -> String)
         -> (forall tp . rtp tp -> String)
         -> MapF ktp rtp
         -> String
-showMap ppk ppv m = "{ " ++ intercalate ", " l ++ " }"
+showMap ppk ppv m = "{ " ++ List.intercalate ", " l ++ " }"
   where l = foldrWithKey (\k a l0 -> (ppk k ++ " -> " ++ ppv a) : l0) [] m
 
 ------------------------------------------------------------------------
@@ -522,7 +522,7 @@ updateAtKey k onNotFound onFound t = ins <$> atKey' k onNotFound onFound t
 
 -- | Create a Map from a list of pairs.
 fromList :: OrdF k => [Pair k a] -> MapF k a
-fromList = foldl' (\m (Pair k a) -> insert k a m) Data.Parameterized.Map.empty
+fromList = List.foldl' (\m (Pair k a) -> insert k a m) Data.Parameterized.Map.empty
 
 -- | Return list of key-values pairs in map in ascending order.
 toAscList :: MapF k a -> [Pair k a]


### PR DESCRIPTION
`base-4.20` (bundled with GHC 9.10) re-exports `foldl'` from the `Prelude`. This causes an `-Wunused-imports` warning when building `Data.Parameterized.Map`, which separately imports `foldl'` from `Data.List`.

This patch makes the `Data.List` import qualified to avoid this issue and make it possible to build the code warning-free on GHC 9.10 and older.