### PR TITLE
ci: Enable `-Werror=compat -Werror=default`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,8 @@ jobs:
         run: cabal check
       - name: Configure
         shell: bash
-        run: cabal configure --enable-tests
+        # See doc/dev.md for development practices around warnings.
+        run: cabal configure --enable-tests --ghc-options='-Werror=compat -Werror=default'
       - name: Build
         shell: bash
         run: cabal build

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -2,14 +2,21 @@
 
 ## Warnings
 
-`parameterized-utils` is a research-grade codebase, so correctness in all cases is not *always* the highest priority.
-In particular, as developers, we must weigh the cost of development practices that prioritize correctness, uniformity, or other concerns against our desire to encourage relatively rapid prototyping of interesting functionality.
+`parameterized-utils` is a research-grade codebase.
+As developers, we should therefore adopt development practices that enable relatively rapid and frictionless prototyping of interesting functionality.
+However, correctness remains a major concern, and we should be willing to invest some effort in practices that reduce bugs.
 When forming judgements about appropriate practices, it is worth remembering that `parameterized-utils` is also upstream of a substantial number of projects, such as What4, Crucible, and Macaw.
 
 The developers currently judge that the warnings included in GHC's `-Wdefault` are conservative enough to be worth fixing in most cases.
-Accordingly, the current default development practice is to fix instances of `-Wdefault` in new code.
+The documentation for `-Wdefault` [states](https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag-Wdefault) that they are:
+
+> a standard set of warnings which are generally likely to indicate bugs in your program[^wdefault]
+
+Given that correctness is a high priority, the current default development practice is to fix instances of `-Wdefault` in new code.
 However, we also trust one anothers' judgement to override this practice in any particular case.
 When doing so, developers are encouraged to disable individual warnings on a per-module basis, ideally accompanied by a comment including some justification for why the warnings were not (and/or should not be) fixed.
 To prevent warnings from slipping in unnoticed and thus unexamined, we enable `-Werror=default` in CI.
 
 We also enable `-Werror=compat` in order to gradually prepare for breaking changes in GHC.
+
+[^wdefault]: Unfortunately, this is not strictly true. `-Wdefault` includes (for example) `-Wtabs`, which is about code style, and `-Winaccessible-code`, which is about dead code. However, the majority of the warnings in `-Wdefault` do indeed affect correctness, and hence should generally be fixed.

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -19,4 +19,9 @@ To prevent warnings from slipping in unnoticed and thus unexamined, we enable `-
 
 We also enable `-Werror=compat` in order to gradually prepare for breaking changes in GHC.
 
+To reproduce the behavior of the CI build locally, developers can run
+```sh
+cabal configure --enable-tests --ghc-options='-Werror=compat -Werror=default'
+```
+
 [^wdefault]: Unfortunately, this is not strictly true. `-Wdefault` includes (for example) `-Wtabs`, which is about code style, and `-Winaccessible-code`, which is about dead code. However, the majority of the warnings in `-Wdefault` do indeed affect correctness, and hence should generally be fixed.

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,0 +1,15 @@
+# Developer documentation
+
+## Warnings
+
+`parameterized-utils` is a research-grade codebase, so correctness in all cases is not *always* the highest priority.
+In particular, as developers, we must weigh the cost of development practices that prioritize correctness, uniformity, or other concerns against our desire to encourage relatively rapid prototyping of interesting functionality.
+When forming judgements about appropriate practices, it is worth remembering that `parameterized-utils` is also upstream of a substantial number of projects, such as What4, Crucible, and Macaw.
+
+The developers currently judge that the warnings included in GHC's `-Wdefault` are conservative enough to be worth fixing in most cases.
+Accordingly, the current default development practice is to fix instances of `-Wdefault` in new code.
+However, we also trust one anothers' judgement to override this practice in any particular case.
+When doing so, developers are encouraged to disable individual warnings on a per-module basis, ideally accompanied by a comment including some justification for why the warnings were not (and/or should not be) fixed.
+To prevent warnings from slipping in unnoticed and thus unexamined, we enable `-Werror=default` in CI.
+
+We also enable `-Werror=compat` in order to gradually prepare for breaking changes in GHC.

--- a/src/Data/Parameterized/ClassesC.hs
+++ b/src/Data/Parameterized/ClassesC.hs
@@ -20,6 +20,9 @@ Note that there is still some ambiguity around naming conventions, see
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeOperators #-}
 
+-- See https://github.com/GaloisInc/parameterized-utils/issues/149
+{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
+
 module Data.Parameterized.ClassesC
   ( TestEqualityC(..)
   , OrdC(..)


### PR DESCRIPTION
To prevent warnings sneaking in without us noticing! Also, switch to a non-deprecated Haskell setup action to get a non-ancient version of Cabal.

I don't feel strongly about this, just thought it would be nice and figured we could do it if we all agreed.