### PR TITLE
Add `EqF` instances for parity with `TestEquality`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@
 
   * `{Functor,Foldable,Traversable}FC` instances for `TypeAp`
 
+  * `EqF` instances for `Assignment`, `BoolRepr`, `Index`, `List`, `NatRepr`,
+    `Nonce`, `PairRepr`, `PeanoRepr`, and `SymbolRepr`
+
 ## 2.1.9.0 -- *2024 Sep 19*
 
   * Add support for GHC 9.10.

--- a/src/Data/Parameterized/BoolRepr.hs
+++ b/src/Data/Parameterized/BoolRepr.hs
@@ -74,6 +74,9 @@ instance Hashable (BoolRepr n) where
 instance Eq (BoolRepr m) where
   _ == _ = True
 
+instance EqF BoolRepr where
+  eqF _ _ = True
+
 instance TestEquality BoolRepr where
   testEquality TrueRepr TrueRepr   = Just Refl
   testEquality FalseRepr FalseRepr = Just Refl

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -282,6 +282,9 @@ indexVal (IndexThere idx) = indexVal idx
 instance Eq (Index ctx tp) where
   idx1 == idx2 = isJust (testEquality idx1 idx2)
 
+instance EqF (Index ctx) where
+  eqF idx1 idx2 = isJust (testEquality idx1 idx2)
+
 instance TestEquality (Index ctx) where
   testEquality (IndexHere _) (IndexHere _) = Just Refl
   testEquality (IndexHere _) (IndexThere _) = Nothing
@@ -546,6 +549,11 @@ a !^ i = a ! extendIndex i
 
 instance TestEquality f => Eq (Assignment f ctx) where
   x == y = isJust (testEquality x y)
+
+instance EqF f => EqF (Assignment f) where
+  eqF AssignmentEmpty AssignmentEmpty = True
+  eqF (AssignmentExtend ctx1 x1) (AssignmentExtend ctx2 x2) =
+    eqF ctx1 ctx2 && eqF x1 x2
 
 testEq :: (forall x y. f x -> f y -> Maybe (x :~: y))
        -> Assignment f cxt1 -> Assignment f cxt2 -> Maybe (cxt1 :~: cxt2)

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -247,6 +247,9 @@ type role Index nominal nominal
 instance Eq (Index ctx tp) where
   Index i == Index j = i == j
 
+instance EqF (Index ctx) where
+  eqF (Index i) (Index j) = i == j
+
 instance TestEquality (Index ctx) where
   testEquality (Index i) (Index j)
     | i == j = Just unsafeAxiom
@@ -829,6 +832,14 @@ instance TestEqualityFC Assignment where
    testEqualityFC test (Assignment x) (Assignment y) = do
      Refl <- testEqualityFC test x y
      return Refl
+
+instance EqF f => EqF (Assignment f) where
+  eqF x y =
+    case (viewAssign x, viewAssign y) of
+      (AssignEmpty, AssignEmpty) ->
+        True
+      (AssignExtend ctx1 x1, AssignExtend ctx2 x2) ->
+        eqF ctx1 ctx2 && eqF x1 x2
 
 instance TestEquality f => TestEquality (Assignment f) where
   testEquality = testEqualityFC testEquality

--- a/src/Data/Parameterized/DataKind.hs
+++ b/src/Data/Parameterized/DataKind.hs
@@ -37,6 +37,9 @@ instance ( ShowF f, ShowF g ) => Show (PairRepr f g p) where
 instance ( ShowF f, ShowF g ) => ShowF (PairRepr f g)
 
 deriving instance ( Eq (f a), Eq (g b) ) => Eq (PairRepr f g '(a, b))
+instance ( EqF f, EqF g ) => EqF (PairRepr f g) where
+  eqF (PairRepr a1 b1) (PairRepr a2 b2) =
+    eqF a1 a2 && eqF b1 b2
 instance ( TestEquality f, TestEquality g ) => TestEquality (PairRepr f g) where
   testEquality =
     $(TH.structuralTypeEquality [t|PairRepr|]

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -214,6 +214,12 @@ instance TestEquality f => TestEquality (List f) where
     pure Refl
   testEquality _ _ = Nothing
 
+instance EqF f => EqF (List f) where
+  eqF Nil Nil =
+    True
+  eqF (xh :< xl) (yh :< yl) =
+    eqF xh yh && eqF xl yl
+
 instance OrdF f => OrdF (List f) where
   compareF Nil Nil = EQF
   compareF Nil _ = LTF

--- a/src/Data/Parameterized/NatRepr/Internal.hs
+++ b/src/Data/Parameterized/NatRepr/Internal.hs
@@ -48,6 +48,9 @@ type role NatRepr nominal
 instance Eq (NatRepr m) where
   _ == _ = True
 
+instance EqF NatRepr where
+  eqF _ _ = True
+
 instance TestEquality NatRepr where
   testEquality (NatRepr m) (NatRepr n)
     | m == n = Just unsafeAxiom

--- a/src/Data/Parameterized/Nonce.hs
+++ b/src/Data/Parameterized/Nonce.hs
@@ -131,6 +131,9 @@ newtype Nonce (s :: Type) (tp :: k) = Nonce { indexValue :: Word64 }
 --  the nonce abstraction.
 type role Nonce nominal nominal
 
+instance EqF (Nonce s) where
+  eqF x y = isJust (testEquality x y)
+
 instance TestEquality (Nonce s) where
   testEquality x y | indexValue x == indexValue y = Just unsafeAxiom
                    | otherwise = Nothing

--- a/src/Data/Parameterized/Nonce/Unsafe.hs
+++ b/src/Data/Parameterized/Nonce/Unsafe.hs
@@ -64,6 +64,9 @@ newtype Nonce (tp :: k) = Nonce { indexValue :: Word64 }
 --  the nonce abstraction.
 type role Nonce nominal
 
+instance EqF Nonce where
+  eqF x y = isJust (testEquality x y)
+
 instance TestEquality Nonce where
   testEquality x y | indexValue x == indexValue y = Just unsafeAxiom
                    | otherwise = Nothing

--- a/src/Data/Parameterized/Peano.hs
+++ b/src/Data/Parameterized/Peano.hs
@@ -219,6 +219,9 @@ instance Hashable (PeanoRepr n) where
 instance Eq (PeanoRepr m) where
   _ == _ = True
 
+instance EqF PeanoRepr where
+  eqF _ _ = True
+
 instance TestEquality PeanoRepr where
 #ifdef UNSAFE_OPS
   testEquality (PeanoRepr m) (PeanoRepr n)

--- a/src/Data/Parameterized/SymbolRepr.hs
+++ b/src/Data/Parameterized/SymbolRepr.hs
@@ -95,6 +95,8 @@ instance OrdF SymbolRepr where
 -- symbol
 instance Eq (SymbolRepr x) where
    _ == _ = True
+instance EqF SymbolRepr where
+   eqF _ _ = True
 instance Ord (SymbolRepr x) where
    compare _ _ = EQ
 


### PR DESCRIPTION
The library defined several `TestEquality` instances that lacked corresponding `EqF` instances. This patch adds these missing `EqF` instances. Where possible, I ensured that only `EqF` constraints are occurred (lest we end up with strange instances like `instance TestEquality f => EqF (T f)`, which are less general than they could be).

This is one step towards a resolution for #129.