### PR TITLE
doc: Describe GHC version support policy

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,5 +1,27 @@
 # Developer documentation
 
+## GHC versions
+
+We support at least three versions of GHC at a time.
+Older versions may be dropped from CI.
+We try to support new versions as soon as they are supported by all of libraries that we depend on.
+
+### Adding a new version
+
+The following checklist enumerates the steps needed to support a new version of GHC.
+When performing such an upgrade, it can be helpful to copy/paste this list into the MR description and check off what has been done, so as to not forget anything.
+
+- [ ] Allow the new version of `base` in the Cabal `build-depends`
+- [ ] Fix any new warnings from `-Wdefault`
+- [ ] Add the new GHC version to the matrix in the Github Actions configuration
+- [ ] Add the new GHC version to the Cabal `tested-with` field
+- [ ] Optionally follow the below steps to remove any old GHC versions
+
+### Removing an old version
+
+- [ ] Remove the old version from the matrix in the Github Actions configuration
+- [ ] Remove the old version from the Cabal `tested-with` field
+
 ## Warnings
 
 `parameterized-utils` is a research-grade codebase.

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -13,13 +13,13 @@ When performing such an upgrade, it can be helpful to copy/paste this list into 
 
 - [ ] Allow the new version of `base` in the Cabal `build-depends`
 - [ ] Fix any new warnings from `-Wdefault`
-- [ ] Add the new GHC version to the matrix in the Github Actions configuration
+- [ ] Add the new GHC version to the matrix in the GitHub Actions configuration
 - [ ] Add the new GHC version to the Cabal `tested-with` field
 - [ ] Optionally follow the below steps to remove any old GHC versions
 
 ### Removing an old version
 
-- [ ] Remove the old version from the matrix in the Github Actions configuration
+- [ ] Remove the old version from the matrix in the GitHub Actions configuration
 - [ ] Remove the old version from the Cabal `tested-with` field
 
 ## Warnings

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -3,7 +3,7 @@
 ## GHC versions
 
 We support at least three versions of GHC at a time.
-We are not aggressive about dropping older versions, but will generally do so for versions outside of the support window if maintaining that support would require efforts such as C pre-processor `ifdef` sections or Cabal `if` sections.
+We are not aggressive about dropping older versions, but will generally do so for versions outside of the support window if maintaining that support would require efforts such as significant numbers of C pre-processor `ifdef` sections or Cabal `if` sections.
 We try to support new versions as soon as they are supported by the libraries that we depend on.
 
 ### Adding a new version

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -3,8 +3,8 @@
 ## GHC versions
 
 We support at least three versions of GHC at a time.
-Older versions may be dropped from CI.
-We try to support new versions as soon as they are supported by all of libraries that we depend on.
+We are not aggressive about dropping older versions, but will generally do so for versions outside of the support window if maintaining that support would require efforts such as C pre-processor `ifdef` sections or Cabal `if` sections.
+We try to support new versions as soon as they are supported by the libraries that we depend on.
 
 ### Adding a new version
 
@@ -12,8 +12,10 @@ The following checklist enumerates the steps needed to support a new version of 
 When performing such an upgrade, it can be helpful to copy/paste this list into the MR description and check off what has been done, so as to not forget anything.
 
 - [ ] Allow the new version of `base` in the Cabal `build-depends`
+- [ ] Run `cabal {build,test,haddock}`, bumping dependency bounds as needed
 - [ ] Fix any new warnings from `-Wdefault`
 - [ ] Add the new GHC version to the matrix in the GitHub Actions configuration
+- [ ] Add the new version to the code that sets `GHC_NIXPKGS` in the CI config
 - [ ] Add the new GHC version to the Cabal `tested-with` field
 - [ ] Optionally follow the below steps to remove any old GHC versions
 
@@ -21,6 +23,8 @@ When performing such an upgrade, it can be helpful to copy/paste this list into 
 
 - [ ] Remove the old version from the matrix in the GitHub Actions configuration
 - [ ] Remove the old version from the Cabal `tested-with` field
+- [ ] Remove outdated CPP `ifdef`s that refer to the dropped version
+- [ ] Remove outdated `if` stanzas in the Cabal file
 
 ## Warnings
 


### PR DESCRIPTION
Also add instructions on how to add or remove GHC versions. I find this helpful because the steps can be different for different repos (e.g., repos may or may not have a `tested-with` field, Cabal freeze files, Dockerfiles, etc.).

I have no particular commitment to the three-version policy, it's just the de facto standard amongst our projects.