### PR TITLE
ci: Publish haddocks to GitHub Pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     concurrency:
       # Only run one of these at a time because they update the global pages.
-      group: haddock
+      group: pages
       cancel-in-progress: false
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,11 @@ jobs:
           restore-keys: |
             ${{ env.key }}-
       - name: Build haddocks
-        run: cabal haddock --haddock-output-dir=doc
+        run: >
+          cabal
+          haddock
+          --haddock-output-dir=doc
+          --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs'
         shell: bash
       - name: Upload artifact with haddocks to GitHub Pages
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Build and Test
+name: Build, test, and document
 on:
   - push
   - pull_request
 jobs:
-  linux:
+  test:
     name: Testing ${{ matrix.os }} GHC-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
@@ -91,9 +91,6 @@ jobs:
       - name: Test
         shell: bash
         run: cabal test
-      - name: Documentation
-        shell: bash
-        run: cabal haddock
       - uses: actions/cache/save@v4
         name: Save cabal store cache
         if: always()
@@ -102,3 +99,58 @@ jobs:
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}
+
+  doc:
+    name: Publish haddocks to GitHub Pages
+    needs: test
+    env:
+      ghc: "9.10.1"
+      os: "ubuntu-24.04"
+    # For some reason, can't use ${{ env.os }} here, so just be sure to keep
+    # this in sync with the line above.
+    runs-on: "ubuntu-24.04"
+    concurrency:
+      # Only run one of these at a time because they update the global pages.
+      group: haddock
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ env.ghc }}
+      - uses: actions/cache/restore@v4
+        name: Restore Cabal cache
+        env:
+          key: cabal-${{ env.os }}-ghc${{ env.ghc }}
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-newstyle
+          key: |
+            ${{ env.key }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.key }}-
+      - name: Build haddocks
+        run: cabal haddock --haddock-output-dir=doc
+        shell: bash
+      - name: Upload artifact with haddocks to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/master' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc'
+        with:
+          path: doc/parameterized-utils
+      - name: Deploy haddocks to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        if: github.ref == 'refs/heads/master' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
           # NB: Each `matrix.os` (e.g., `ubuntu-22.04-arm`) uniquely determines
           # a `runner.arch` (e.g., ARM64), so there is no need to include the
           # latter as part of the cache key
+          #
+          # Any changes to this key should be reflected in the `doc` job below.
           key: cabal-${{ matrix.os }}-ghc${{ matrix.ghc }}
         with:
           path: |
@@ -126,6 +128,8 @@ jobs:
         id: setup-haskell
         with:
           ghc-version: ${{ env.ghc }}
+      # Note that this uses (but does not modify) the cache from the `test`
+      # step. They use all the same dependencies, so this is appropriate.
       - uses: actions/cache/restore@v4
         name: Restore Cabal cache
         env:

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -15,6 +15,7 @@ When performing such an upgrade, it can be helpful to copy/paste this list into 
 - [ ] Run `cabal {build,test,haddock}`, bumping dependency bounds as needed
 - [ ] Fix any new warnings from `-Wdefault`
 - [ ] Add the new GHC version to the matrix in the GitHub Actions configuration
+- [ ] Change the `doc` job to use the new GHC version
 - [ ] Add the new version to the code that sets `GHC_NIXPKGS` in the CI config
 - [ ] Add the new GHC version to the Cabal `tested-with` field
 - [ ] Optionally follow the below steps to remove any old GHC versions


### PR DESCRIPTION
In between full Hackage releases, it would be nice to be able to read haddocks for the latest commit on the default branch. This PR builds the haddocks in CI, and publishes them to GitHub Pages.

In more detail, this PR breaks the `cabal haddock` step out of the testing job into a separate job for the sake of controlling concurrency and permissions, while reusing the cache from the build step to build the haddocks.

I'd be completetly fine with hearing that we don't think that the maintenance is worth it, I mostly wanted to prototype this for use on our repos that we don't publish to Hackage (e.g., Macaw) and just figured I'd make a PR in case others thought this would be useful.

If we did want to merge this, we would want to temporarily disable the `if` stanza that only deploys on the `master` branch, to try it out.