### PR TITLE
ci: Move Haddocks to their own workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,71 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+    - master
+
+concurrency:
+  # Only run one of these at a time because they update the global GitHub Pages.
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    runs-on: ${{ matrix.os }}
+    name: Documentation
+    # This matrix is defined not in order to build multiple copies of the
+    # documentation in different configurations, but rather just to DRY the OS
+    # and GHC version. `runs-on` can't access variables from a top-level `env`
+    # block, only from `matrix`.
+    strategy:
+      matrix:
+        os: ["ubuntu-24.04"]
+        ghc: ["9.10.1"]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: haskell-actions/setup@v2
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - uses: actions/cache@v4
+      name: Restore Cabal cache
+      env:
+        key: haddock-${{ matrix.os }}-ghc${{ matrix.ghc }}
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key: |
+          ${{ env.key }}-${{ github.ref }}
+        restore-keys: |
+          ${{ env.key }}-
+    - name: Build haddocks
+      run: >
+        cabal
+        haddock
+        --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs'
+        --haddock-hyperlink-source
+        --haddock-output-dir=doc
+        --haddock-quickjump
+      shell: bash
+    - name: Upload artifact with haddocks to GitHub Pages
+      uses: actions/upload-pages-artifact@v3
+      if: github.ref == 'refs/heads/master' &&
+          github.event.pull_request.head.repo.fork == false &&
+          github.repository_owner == 'GaloisInc'
+      with:
+        path: doc/parameterized-utils
+    - name: Deploy haddocks to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+      if: github.ref == 'refs/heads/master' &&
+          github.event.pull_request.head.repo.fork == false &&
+          github.repository_owner == 'GaloisInc'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build, test, and document
+name: Build and test
 on:
   - push
   - pull_request
@@ -34,8 +34,6 @@ jobs:
           # NB: Each `matrix.os` (e.g., `ubuntu-22.04-arm`) uniquely determines
           # a `runner.arch` (e.g., ARM64), so there is no need to include the
           # latter as part of the cache key
-          #
-          # Any changes to this key should be reflected in the `doc` job below.
           key: cabal-${{ matrix.os }}-ghc${{ matrix.ghc }}
         with:
           path: |
@@ -86,13 +84,28 @@ jobs:
       - name: Configure
         shell: bash
         # See doc/dev.md for development practices around warnings.
-        run: cabal configure --enable-tests --ghc-options='-Werror=compat -Werror=default'
+        run: cabal configure --disable-documentation --enable-tests --ghc-options='-Werror=compat -Werror=default'
       - name: Build
         shell: bash
         run: cabal build
       - name: Test
         shell: bash
         run: cabal test
+      - name: Documentation
+        shell: bash
+        # Build the Haddocks to ensure that they are well formed. Somewhat
+        # counterintuitively, we run this with the --disable-documentation flag.
+        # This does not mean "do not build the Haddocks", but rather, "build the
+        # Haddocks for the top-level library, but do not build dependencies with
+        # Haddocks". The upshot is that we do not change the build configuration
+        # for any dependencies, which means that we don't have to rebuild them.
+        # The downside is that the rendered Haddocks won't contain any links
+        # to identifiers from library dependencies. Since we are only building
+        # Haddocks to ensure well-formedness, we consider this an acceptable
+        # tradeoff.
+        #
+        # We build the full Haddocks in the "Documentation" workflow.
+        run: cabal haddock --disable-documentation
       - uses: actions/cache/save@v4
         name: Save cabal store cache
         if: always()
@@ -101,64 +114,3 @@ jobs:
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}
-
-  doc:
-    name: Publish haddocks to GitHub Pages
-    needs: test
-    env:
-      ghc: "9.10.1"
-      os: "ubuntu-24.04"
-    # For some reason, can't use ${{ env.os }} here, so just be sure to keep
-    # this in sync with the line above.
-    runs-on: "ubuntu-24.04"
-    concurrency:
-      # Only run one of these at a time because they update the global pages.
-      group: pages
-      cancel-in-progress: false
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: haskell-actions/setup@v2
-        id: setup-haskell
-        with:
-          ghc-version: ${{ env.ghc }}
-      # Note that this uses (but does not modify) the cache from the `test`
-      # step. They use all the same dependencies, so this is appropriate.
-      - uses: actions/cache/restore@v4
-        name: Restore Cabal cache
-        env:
-          key: cabal-${{ env.os }}-ghc${{ env.ghc }}
-        with:
-          path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
-            dist-newstyle
-          key: |
-            ${{ env.key }}-${{ github.ref }}
-          restore-keys: |
-            ${{ env.key }}-
-      - name: Build haddocks
-        run: >
-          cabal
-          haddock
-          --haddock-output-dir=doc
-          --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs'
-        shell: bash
-      - name: Upload artifact with haddocks to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/master' &&
-            github.event.pull_request.head.repo.fork == false &&
-            github.repository_owner == 'GaloisInc'
-        with:
-          path: doc/parameterized-utils
-      - name: Deploy haddocks to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        if: github.ref == 'refs/heads/master' &&
-            github.event.pull_request.head.repo.fork == false &&
-            github.repository_owner == 'GaloisInc'


### PR DESCRIPTION
The setup I introduced in #183 was buggy. The `doc` job would fail on non-`master` branches, because it didn't have enough permissions to access the GitHub Pages "environment", even though if it were run it wouldn't attempt to upload to it.

Also, use a separate cache for documentation builds. This is appropriate, as we can and should build with `--disable-documentation` to save space and time in the `test` job, but *not* build with that flag for the docs. This discrepancy causes dependencies to be built differently, hence separate caches.

Return to checking Haddock well-formedness in `test`.