### PR TITLE
ci: Simplify, move, and document the Cabal/GHC compatibility check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,6 @@ jobs:
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
-      - name: Install Nix
-        uses: cachix/install-nix-action@v16
-        with:
-          nix_path: nixpkgs=channel:nixos-21.11
-          install_url: https://releases.nixos.org/nix/nix-2.11.0/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - uses: actions/cache/restore@v4
         name: Restore cabal store cache
         id: cache
@@ -46,38 +39,6 @@ jobs:
       - name: Cabal update
         shell: bash
         run: cabal update
-      - name: Setup Environment Vars
-        # Setup a nix shell environment command that will supply the
-        # appropriate GHC version
-        run: |
-          GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
-          echo GHC=$GHC >> $GITHUB_ENV
-          case ${{ matrix.ghc }} in
-            8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
-            9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
-            9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
-            9.4.5) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
-            9.6.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
-            9.8.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.11 ;;
-            9.10.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
-          esac
-          echo NS="nix shell ${GHC_NIXPKGS}#${GHC}" >> $GITHUB_ENV
-      - name: Package's Cabal/GHC compatibility
-        shell: bash
-        # Using setup will use the cabal library installed with GHC
-        # instead of the cabal library of the Cabal-install tool to
-        # verify the cabal file is compatible with the associated
-        # GHC cabal library version.  Cannot run "configure" or "build",
-        # because dependencies aren't present, but a "clean" is
-        # sufficient to cause parsing/validation of the cabal file.
-        run: |
-          defsetup()  { echo import Distribution.Simple; echo main = defaultMain; }
-          setup_src() { if [ ! -f Setup.hs ] ; then defsetup > DefSetup.hs; fi; ls *Setup.hs; }
-          setup_bin() { echo setup.${{ matrix.ghc }}; }
-          with_ghc()  { $NS -c ${@}; }
-          echo "github.com=${{ secrets.GITHUB_TOKEN }}" >> nix.conf
-          with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean
       - name: Cabal check
         shell: bash
         run: cabal check
@@ -114,3 +75,25 @@ jobs:
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}
+      - name: Check Cabal/GHC compatibility
+        shell: bash
+        # We support older Cabal versions so that users can build the project
+        # even if they lack access to the latest Cabal package, e.g., when using
+        # the version provided by their OS package manager on older systems.
+        #
+        # Rather than running the whole CI workflow with multiple Cabal versions
+        # (e.g., in the `matrix`), we run the equivalent of `cabal clean`, but
+        # using the version of the Cabal library that is bundled with GHC. This
+        # is sufficient to check that the bundled version of Cabal can parse the
+        # Cabal configuration files (`.cabal`, `cabal.project{,freeze}`).
+        #
+        # This guarantees that our package can be built with the versions of
+        # Cabal that are likely to be available alongside our supported versions
+        # of GHC.
+        #
+        # We run this after `actions/cache/save` since it deletes most of
+        # `dist-newstyle`.
+        run: |
+          echo 'import Distribution.Simple; main = defaultMain' > Setup.hs
+          ghc -o setup Setup.hs
+          ./setup clean

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,5 +95,4 @@ jobs:
         # `dist-newstyle`.
         run: |
           echo 'import Distribution.Simple; main = defaultMain' > Setup.hs
-          ghc -o setup Setup.hs
-          ./setup clean
+          runhaskell Setup.hs clean


### PR DESCRIPTION
I was making a composite action for this (#182), but I realized that it could likely be simplified instead, to the point where such an action would be superfluous! I believe it still addresses the original concerns behind this check, but would appreciate confirmation from @kquick.

Added some more documentation along the lines of https://github.com/GaloisInc/.github/pull/13.