### PR TITLE
Remove unused dependency `ghc-prim` from Cabal file

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -56,7 +56,6 @@ library
                , constraints    >=0.10 && <0.15
                , containers
                , deepseq
-               , ghc-prim
                , hashable       >=1.2  && <1.6
                , hashtables     >=1.2  && <1.5
                , indexed-traversable
@@ -137,7 +136,6 @@ test-suite parameterizedTests
                , hashtables
                , hedgehog
                , indexed-traversable
-               , ghc-prim
                , lens
                , mtl
                , parameterized-utils


### PR DESCRIPTION
Found with

    cabal configure --ghc-options='-Werror=unused-packages' && cabal build all