### PR TITLE
Drop `lens` in favor of `microlens{,-pro}`

### DIFF
--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -60,7 +60,6 @@ library
                , hashtables     >=1.2  && <1.5
                , indexed-traversable
                , microlens      >=0.4  && <0.5
-               , microlens-pro  >=0.2  && <0.3
                , mtl
                , profunctors    >=5.6 && < 5.7
                , template-haskell

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -59,7 +59,8 @@ library
                , hashable       >=1.2  && <1.6
                , hashtables     >=1.2  && <1.5
                , indexed-traversable
-               , lens           >=4.16 && <5.4
+               , microlens      >=0.4  && <0.5
+               , microlens-pro  >=0.2  && <0.3
                , mtl
                , profunctors    >=5.6 && < 5.7
                , template-haskell

--- a/src/Data/Parameterized/Classes.hs
+++ b/src/Data/Parameterized/Classes.hs
@@ -68,7 +68,7 @@ import Data.Type.Equality as Equality
 
 import Data.Parameterized.Compose ()
 
--- We define these type alias here to avoid importing Control.Lens
+-- We define these type alias here to avoid importing Lens.Micro
 -- modules, as this apparently causes problems with the safe Hasekll
 -- checking.
 type Lens' s a = forall f. Functor f => (a -> f a) -> s -> f s

--- a/src/Data/Parameterized/Context.hs
+++ b/src/Data/Parameterized/Context.hs
@@ -103,7 +103,7 @@ module Data.Parameterized.Context
 import           Prelude hiding (unzip)
 
 import qualified Control.Applicative as App (liftA2)
-import           Control.Lens hiding (Index, (:>), Empty)
+import           Lens.Micro
 import           Data.Functor (void)
 import           Data.Functor.Product (Product(Pair))
 import           Data.Kind
@@ -301,7 +301,7 @@ data CtxEmbedding (ctx :: Ctx k) (ctx' :: Ctx k)
 --   ExtendBoth :: CtxEmbedding ctx ctx' -> CtxEmbedding (ctx ::> tp) (ctx' ::> tp)
 --   ExtendOne  :: CtxEmbedding ctx ctx' -> CtxEmbedding ctx (ctx' ::> tp)
 
-ctxeSize :: Simple Lens (CtxEmbedding ctx ctx') (Size ctx')
+ctxeSize :: Lens' (CtxEmbedding ctx ctx') (Size ctx')
 ctxeSize = lens _ctxeSize (\s v -> s { _ctxeSize = v })
 
 ctxeAssignment :: Lens (CtxEmbedding ctx1 ctx') (CtxEmbedding ctx2 ctx')

--- a/src/Data/Parameterized/Context/Safe.hs
+++ b/src/Data/Parameterized/Context/Safe.hs
@@ -111,7 +111,8 @@ module Data.Parameterized.Context.Safe
 
 import qualified Control.Category as Cat
 import Control.DeepSeq
-import qualified Control.Lens as Lens
+import qualified Lens.Micro as Lens
+import qualified Lens.Micro.Internal as Lens (Field1, Field2, Field3, Field4, Field5)
 import Control.Monad.Identity (Identity(..))
 import Data.Hashable
 import Data.List (intercalate)
@@ -893,13 +894,6 @@ instance Lens.Field5 (Assignment6 f x1 x2 x3 x4 t x6)
   _5 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
         where n = MySR $ MyZR
 
-instance Lens.Field6 (Assignment6 f x1 x2 x3 x4 x5 t)
-                     (Assignment6 f x1 x2 x3 x4 x5 u)
-                     (f t)
-                     (f u) where
-  _6 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MyZR
-
 ------------------------------------------------------------------------
 -- 7 field lens combinators
 
@@ -940,20 +934,6 @@ instance Lens.Field5 (Assignment7 f x1 x2 x3 x4 t x6 x7)
                      (f u) where
   _5 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
         where n = MySR $ MySR $ MyZR
-
-instance Lens.Field6 (Assignment7 f x1 x2 x3 x4 x5 t x7)
-                     (Assignment7 f x1 x2 x3 x4 x5 u x7)
-                     (f t)
-                     (f u) where
-  _6 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MySR $ MyZR
-
-instance Lens.Field7 (Assignment7 f x1 x2 x3 x4 x5 x6 t)
-                     (Assignment7 f x1 x2 x3 x4 x5 x6 u)
-                     (f t)
-                     (f u) where
-  _7 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MyZR
 
 ------------------------------------------------------------------------
 -- 8 field lens combinators
@@ -997,27 +977,6 @@ instance Lens.Field5 (Assignment8 f x1 x2 x3 x4 t x6 x7 x8)
   _5 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
         where n = MySR $ MySR $ MySR $ MyZR
 
-instance Lens.Field6 (Assignment8 f x1 x2 x3 x4 x5 t x7 x8)
-                     (Assignment8 f x1 x2 x3 x4 x5 u x7 x8)
-                     (f t)
-                     (f u) where
-  _6 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MySR $ MySR $ MyZR
-
-instance Lens.Field7 (Assignment8 f x1 x2 x3 x4 x5 x6 t x8)
-                     (Assignment8 f x1 x2 x3 x4 x5 x6 u x8)
-                     (f t)
-                     (f u) where
-  _7 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MySR $ MyZR
-
-instance Lens.Field8 (Assignment8 f x1 x2 x3 x4 x5 x6 x7 t)
-                     (Assignment8 f x1 x2 x3 x4 x5 x6 x7 u)
-                     (f t)
-                     (f u) where
-  _8 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MyZR
-
 ------------------------------------------------------------------------
 -- 9 field lens combinators
 
@@ -1059,31 +1018,3 @@ instance Lens.Field5 (Assignment9 f x1 x2 x3 x4 t x6 x7 x8 x9)
                      (f u) where
   _5 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
         where n = MySR $ MySR $ MySR $ MySR $ MyZR
-
-instance Lens.Field6 (Assignment9 f x1 x2 x3 x4 x5 t x7 x8 x9)
-                     (Assignment9 f x1 x2 x3 x4 x5 u x7 x8 x9)
-                     (f t)
-                     (f u) where
-  _6 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MySR $ MySR $ MySR $ MyZR
-
-instance Lens.Field7 (Assignment9 f x1 x2 x3 x4 x5 x6 t x8 x9)
-                     (Assignment9 f x1 x2 x3 x4 x5 x6 u x8 x9)
-                     (f t)
-                     (f u) where
-  _7 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MySR $ MySR $ MyZR
-
-instance Lens.Field8 (Assignment9 f x1 x2 x3 x4 x5 x6 x7 t x9)
-                     (Assignment9 f x1 x2 x3 x4 x5 x6 x7 u x9)
-                     (f t)
-                     (f u) where
-  _8 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MySR $ MyZR
-
-instance Lens.Field9 (Assignment9 f x1 x2 x3 x4 x5 x6 x7 x8 t)
-                     (Assignment9 f x1 x2 x3 x4 x5 x6 x7 x8 u)
-                     (f t)
-                     (f u) where
-  _9 = Lens.lens (mynat_lookup n) (strong_ctx_update n)
-        where n = MyZR

--- a/src/Data/Parameterized/Context/Unsafe.hs
+++ b/src/Data/Parameterized/Context/Unsafe.hs
@@ -90,7 +90,8 @@ module Data.Parameterized.Context.Unsafe
 import qualified Control.Category as Cat
 import           Control.DeepSeq
 import           Control.Exception
-import qualified Control.Lens as Lens
+import qualified Lens.Micro as Lens
+import qualified Lens.Micro.Internal as Lens (Field1, Field2, Field3, Field4, Field5)
 import           Control.Monad.Identity (Identity(..))
 import           Data.Bits
 import           Data.Coerce
@@ -1143,12 +1144,6 @@ instance Lens.Field5 (Assignment6 f x1 x2 x3 x4 t x6)
                      (f u) where
   _5 = unsafeLens 4
 
-instance Lens.Field6 (Assignment6 f x1 x2 x3 x4 x5 t)
-                     (Assignment6 f x1 x2 x3 x4 x5 u)
-                     (f t)
-                     (f u) where
-  _6 = unsafeLens 5
-
 ------------------------------------------------------------------------
 -- 7 field lens combinators
 
@@ -1185,18 +1180,6 @@ instance Lens.Field5 (Assignment7 f x1 x2 x3 x4 t x6 x7)
                      (f t)
                      (f u) where
   _5 = unsafeLens 4
-
-instance Lens.Field6 (Assignment7 f x1 x2 x3 x4 x5 t x7)
-                     (Assignment7 f x1 x2 x3 x4 x5 u x7)
-                     (f t)
-                     (f u) where
-  _6 = unsafeLens 5
-
-instance Lens.Field7 (Assignment7 f x1 x2 x3 x4 x5 x6 t)
-                     (Assignment7 f x1 x2 x3 x4 x5 x6 u)
-                     (f t)
-                     (f u) where
-  _7 = unsafeLens 6
 
 ------------------------------------------------------------------------
 -- 8 field lens combinators
@@ -1235,24 +1218,6 @@ instance Lens.Field5 (Assignment8 f x1 x2 x3 x4 t x6 x7 x8)
                      (f u) where
   _5 = unsafeLens 4
 
-instance Lens.Field6 (Assignment8 f x1 x2 x3 x4 x5 t x7 x8)
-                     (Assignment8 f x1 x2 x3 x4 x5 u x7 x8)
-                     (f t)
-                     (f u) where
-  _6 = unsafeLens 5
-
-instance Lens.Field7 (Assignment8 f x1 x2 x3 x4 x5 x6 t x8)
-                     (Assignment8 f x1 x2 x3 x4 x5 x6 u x8)
-                     (f t)
-                     (f u) where
-  _7 = unsafeLens 6
-
-instance Lens.Field8 (Assignment8 f x1 x2 x3 x4 x5 x6 x7 t)
-                     (Assignment8 f x1 x2 x3 x4 x5 x6 x7 u)
-                     (f t)
-                     (f u) where
-  _8 = unsafeLens 7
-
 ------------------------------------------------------------------------
 -- 9 field lens combinators
 
@@ -1289,27 +1254,3 @@ instance Lens.Field5 (Assignment9 f x1 x2 x3 x4 t x6 x7 x8 x9)
                      (f t)
                      (f u) where
   _5 = unsafeLens 4
-
-instance Lens.Field6 (Assignment9 f x1 x2 x3 x4 x5 t x7 x8 x9)
-                     (Assignment9 f x1 x2 x3 x4 x5 u x7 x8 x9)
-                     (f t)
-                     (f u) where
-  _6 = unsafeLens 5
-
-instance Lens.Field7 (Assignment9 f x1 x2 x3 x4 x5 x6 t x8 x9)
-                     (Assignment9 f x1 x2 x3 x4 x5 x6 u x8 x9)
-                     (f t)
-                     (f u) where
-  _7 = unsafeLens 6
-
-instance Lens.Field8 (Assignment9 f x1 x2 x3 x4 x5 x6 x7 t x9)
-                     (Assignment9 f x1 x2 x3 x4 x5 x6 x7 u x9)
-                     (f t)
-                     (f u) where
-  _8 = unsafeLens 7
-
-instance Lens.Field9 (Assignment9 f x1 x2 x3 x4 x5 x6 x7 x8 t)
-                     (Assignment9 f x1 x2 x3 x4 x5 x6 x7 x8 u)
-                     (f t)
-                     (f u) where
-  _9 = unsafeLens 8

--- a/src/Data/Parameterized/Fin.hs
+++ b/src/Data/Parameterized/Fin.hs
@@ -36,7 +36,7 @@ module Data.Parameterized.Fin
   , fin2Bool
   ) where
 
-import Control.Lens.Iso (Iso', iso)
+import Lens.Micro.Pro (Iso', iso)
 import GHC.TypeNats (KnownNat)
 import Numeric.Natural (Natural)
 import Data.Void (Void, absurd)

--- a/src/Data/Parameterized/Fin.hs
+++ b/src/Data/Parameterized/Fin.hs
@@ -31,15 +31,10 @@ module Data.Parameterized.Fin
   , tryEmbed
   , minFin
   , incFin
-  , fin0Void
-  , fin1Unit
-  , fin2Bool
   ) where
 
-import Lens.Micro.Pro (Iso', iso)
 import GHC.TypeNats (KnownNat)
 import Numeric.Natural (Natural)
-import Data.Void (Void, absurd)
 
 import Data.Parameterized.NatRepr
 
@@ -123,26 +118,3 @@ incFin :: forall n. Fin n -> Fin (n + 1)
 incFin (Fin (i :: NatRepr i)) =
   case leqAdd2 (LeqProof :: LeqProof (i + 1) n) (LeqProof :: LeqProof 1 1) of
     LeqProof -> mkFin (incNat i)
-
-fin0Void :: Iso' (Fin 0) Void
-fin0Void =
-  iso
-    (viewFin
-      (\(x :: NatRepr o) ->
-        case plusComm x (knownNat @1) of
-          Refl ->
-            case addIsLeqLeft1 @1 @o @0 LeqProof of {}))
-    absurd
-
-fin1Unit :: Iso' (Fin 1) ()
-fin1Unit = iso (const ()) (const minFin)
-
-fin2Bool :: Iso' (Fin 2) Bool
-fin2Bool =
-  iso
-    (viewFin
-      (\n ->
-         case isZeroNat n of
-           ZeroNat -> False
-           NonZeroNat -> True))
-    (\b -> if b then maxBound else minBound)

--- a/src/Data/Parameterized/List.hs
+++ b/src/Data/Parameterized/List.hs
@@ -153,7 +153,7 @@ module Data.Parameterized.List
   , index3
   ) where
 
-import qualified Control.Lens as Lens
+import qualified Lens.Micro as Lens
 import           Data.Foldable
 import           Data.Kind
 import           Prelude hiding ((!!))

--- a/src/Data/Parameterized/Map.hs
+++ b/src/Data/Parameterized/Map.hs
@@ -82,7 +82,7 @@ module Data.Parameterized.Map
   ) where
 
 import           Control.Applicative hiding (empty)
-import           Control.Lens (Traversal', Lens')
+import           Lens.Micro (Traversal', Lens')
 import           Control.Monad.Identity (Identity(..))
 import           Control.Monad (foldM)
 import           Data.Kind (Type)

--- a/src/Data/Parameterized/Some.hs
+++ b/src/Data/Parameterized/Some.hs
@@ -20,7 +20,7 @@ module Data.Parameterized.Some
   , someLens
   ) where
 
-import Control.Lens (Lens', lens, (&), (^.), (.~))
+import Lens.Micro (Lens', lens, (&), (^.), (.~))
 import Data.Hashable
 import Data.Kind
 import Data.Parameterized.Classes

--- a/test/Test/Context.hs
+++ b/test/Test/Context.hs
@@ -18,7 +18,7 @@ module Test.Context
   )
 where
 
-import           Control.Lens
+import           Lens.Micro
 import           Data.Functor.Product (Product(Pair))
 import           Data.Kind
 import           Data.Parameterized.Classes

--- a/test/Test/Some.hs
+++ b/test/Test/Some.hs
@@ -7,7 +7,7 @@ module Test.Some
 where
 
 import           Data.Type.Equality (TestEquality(testEquality), (:~:)(Refl))
-import           Control.Lens (Lens', lens, view, set)
+import           Lens.Micro (Lens', lens, view, set)
 
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertEqual, testCase)


### PR DESCRIPTION
Fixes #203. This needs further discussion and would definitely need an entry in the CHANGELOG, but this PR at least shows that this is feasible with a relatively small amount of churn.