### PR TITLE
ci: Bump `haskell-ci` to v2, enable test coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,15 @@ jobs:
         # See doc/dev.md for GHC version support policy
         ghc: [9.12.2, 9.10.1, 9.8.1, 9.6.1, 9.4.5, 9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
       fail-fast: false
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2
     with:
+      cache-key-prefix: v1
       # See doc/dev.md for development practices around warnings.
       #
       # See Note [Parallelism] in `haskell-ci.yml` for why `--ghc-options='-j'`
       # and `--semaphore`.
-      configure-flags: --enable-tests --ghc-options='-Werror=compat -Werror=default -j' --semaphore
+      configure-flags: --enable-coverage --enable-tests --ghc-options='-Werror=compat -Werror=default -j' --semaphore
+      coverage: true
+      coverage-artifact: true
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}


### PR DESCRIPTION
Enables the collection and reporting of code coverage information from the test-suite. Markdown-based reports are added to the "job summary" page  and artifacts containing detailed HTML reports are uploaded for each workflow run.