### PR TITLE
SmallArrayF: A `SmallArray#`-backed datastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2
     with:
-      cache-key-prefix: v2
+      cache-key-prefix: v5
       # See doc/dev.md for development practices around warnings.
       #
       # See Note [Parallelism] in `haskell-ci.yml` for why `--ghc-options='-j'`

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## next
 
+  * Add `Data.Parameterized.SmallArrayF`, a `SmallArray#`-backed container
+    indexed by a type-level context.
+
 ## 2.3.0.0 -- 2026-03-06
 
   * BREAKING: Remove the `Iso`s `fin0Void`, `fin1Unit`, and `fin2Bool`.

--- a/parameterized-utils.cabal
+++ b/parameterized-utils.cabal
@@ -95,6 +95,7 @@ library
     Data.Parameterized.Nonce.Unsafe
     Data.Parameterized.Pair
     Data.Parameterized.Peano
+    Data.Parameterized.SmallArrayF
     Data.Parameterized.Some
     Data.Parameterized.SymbolRepr
     Data.Parameterized.TH.GADT
@@ -125,16 +126,23 @@ test-suite parameterizedTests
     Test.FinMap
     Test.List
     Test.NatRepr
+    Test.SmallArrayF
+    Test.SmallArrayF.Instances
+    Test.SmallArrayF.Rules
+    Test.SmallArrayF.RulesCoverage
+    Test.SmallArrayF.RulesSemantics
     Test.Some
     Test.SymbolRepr
     Test.TH
     Test.Vector
 
   build-depends: base
+               , deepseq
                , hashable
                , hashtables
                , hedgehog
                , indexed-traversable
+               , inspection-testing >= 0.5 && < 0.7
                , microlens >=0.5 && <0.6
                , mtl
                , parameterized-utils
@@ -142,6 +150,7 @@ test-suite parameterizedTests
                , tasty-ant-xml == 1.1.*
                , tasty-hunit >= 0.9 && < 0.11
                , tasty-hedgehog >= 1.2
+               , tasty-inspection-testing >= 0.2 && < 0.3
 
   if impl(ghc >= 8.6)
     build-depends:

--- a/src/Data/Parameterized/SmallArrayF.hs
+++ b/src/Data/Parameterized/SmallArrayF.hs
@@ -1,0 +1,1091 @@
+{-|
+Module : Data.Parameterized.SmallArrayF
+Copyright : (c) Galois, Inc 2026
+Maintainer : Langston Barrett <langston@galois.com>
+
+A type-parameterized, fixed-size, heterogeneous container indexed by
+a type-level 'Data.Parameterized.Ctx.Ctx'.
+
+Compared with 'Data.Parameterized.Context.Assignment', 'SmallArrayF'
+trades \(O(1)\)-amortized 'extend' for \(O(1)\) indexing and \(O(n)\)
+'extend'/'update'.  Intended for small, read-heavy use cases such as
+machine register files.  For incremental construction, build an
+'Data.Parameterized.Context.Assignment' and convert via
+'fromAssignment' at the boundary.
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module Data.Parameterized.SmallArrayF
+  ( SmallArrayF
+    -- * Construction
+  , empty
+  , singleton
+  , from2
+  , from3
+  , from4
+  , from5
+  , from6
+  , from7
+  , from8
+  , from9
+  , generate
+  , generateA
+  , generateST
+  , generateIO
+    -- * Query
+  , (!)
+  , size
+    -- * Modification
+  , update
+  , adjust
+  , adjustM
+  , extend
+  , unextend
+    -- * Combine
+  , zipWithFC
+  , zipWithMFC
+  , zipWithMFCST
+  , zipWithMFCIO
+  , append
+    -- * Subarray
+  , take
+  , drop
+
+    -- * Traversal
+  , traverseFCST
+  , traverseFCIO
+  , itraverseFCST
+  , itraverseFCIO
+
+    -- * Conversion
+  , fromAssignment
+  , toAssignment
+  ) where
+
+import           Prelude hiding (drop, take)
+
+import           Control.DeepSeq (NFData(rnf))
+import           Control.Monad.IO.Class (MonadIO(liftIO))
+import           Control.Monad.ST (ST, runST, stToIO)
+import           Data.Functor.Identity (Identity(Identity, runIdentity))
+import           Data.Kind (Type)
+import           Data.List (intercalate)
+import qualified GHC.Exts as Exts
+import           GHC.Exts (Any, Int(I#), Int#, isTrue#, (>=#), (/=#), (+#), (-#))
+import           GHC.ST (ST(ST))
+import           Unsafe.Coerce (unsafeCoerce)
+
+import qualified Lens.Micro as Lens
+
+import           Data.Parameterized.Axiom (unsafeAxiom)
+import           Data.Parameterized.Classes
+import           Data.Parameterized.Ctx (Ctx, EmptyCtx, type (::>), type (<+>))
+import           Data.Parameterized.Context (Assignment, Index, Size)
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.TraversableFC
+import           Data.Parameterized.TraversableFC.WithIndex
+
+------------------------------------------------------------------------
+-- Representation
+
+-- | A container holding a value @f tp@ at each position prescribed by
+-- the type-level context @ctx@.
+--
+-- Indexing matches 'Data.Parameterized.Context.Assignment': the @i@th
+-- 'Index' refers to the @i@th element left-to-right.
+data SmallArrayF (f :: k -> Type) (ctx :: Ctx k)
+  = SmallArrayF (Exts.SmallArray# (f Any))
+
+type role SmallArrayF nominal nominal
+
+------------------------------------------------------------------------
+-- Primop wrappers
+--
+-- SmallArray# and SmallMutableArray# are unlifted, so we wrap them in
+-- ST-friendly combinators here rather than inline at every use site.
+
+-- A lifted wrapper around SmallMutableArray# so it can flow through ST.
+data MutArr s (f :: k -> Type) = MutArr (Exts.SmallMutableArray# s (f Any))
+
+newMut# :: Int# -> ST s (MutArr s f)
+newMut# n = ST $ \s ->
+  case Exts.newSmallArray# n uninitialized s of
+    (# s', m #) -> (# s', MutArr m #)
+  where
+    uninitialized :: f Any
+    uninitialized = error "Data.Parameterized.SmallArrayF: uninitialized slot"
+{-# INLINE newMut# #-}
+
+writeMut# :: MutArr s f -> Int# -> f Any -> ST s ()
+writeMut# (MutArr m) i x = ST $ \s ->
+  case Exts.writeSmallArray# m i x s of
+    s' -> (# s', () #)
+{-# INLINE writeMut# #-}
+
+freezeMut :: MutArr s f -> ST s (SmallArrayF f ctx)
+freezeMut (MutArr m) = ST $ \s ->
+  case Exts.unsafeFreezeSmallArray# m s of
+    (# s', arr #) -> (# s', SmallArrayF arr #)
+{-# INLINE freezeMut #-}
+
+-- | Copy @n@ elements from a frozen array into a mutable array,
+-- starting at offset 0 in both.
+copyInto# :: Exts.SmallArray# (f Any) -> MutArr s f -> Int# -> ST s ()
+copyInto# src (MutArr dst) n = ST $ \s ->
+  case Exts.copySmallArray# src 0# dst 0# n s of
+    s' -> (# s', () #)
+{-# INLINE copyInto# #-}
+
+-- | Copy @n@ elements from a frozen array starting at @srcOff@ into a
+-- mutable array starting at @dstOff@.
+copyIntoAt# ::
+  Exts.SmallArray# (f Any) ->
+  Int# ->
+  MutArr s f ->
+  Int# ->
+  Int# ->
+  ST s ()
+copyIntoAt# src srcOff (MutArr dst) dstOff n = ST $ \s ->
+  case Exts.copySmallArray# src srcOff dst dstOff n s of
+    s' -> (# s', () #)
+{-# INLINE copyIntoAt# #-}
+
+-- | Read a value from a frozen array at the given unboxed offset.
+index# :: Exts.SmallArray# (f Any) -> Int# -> f Any
+index# arr i = case Exts.indexSmallArray# arr i of (# x #) -> x
+{-# INLINE index# #-}
+
+-- | Number of elements in a frozen array, as an unboxed 'Int#'.
+size# :: Exts.SmallArray# (f Any) -> Int#
+size# arr = Exts.sizeofSmallArray# arr
+{-# INLINE size# #-}
+
+------------------------------------------------------------------------
+-- Iteration and folds over raw arrays
+
+-- | @forN_ n k@ executes @k 0#@, @k 1#@, ..., @k (n-1)#@ in order.
+forN_ :: Applicative m => Int# -> (Int# -> m ()) -> m ()
+forN_ n k = go 0#
+  where
+    go i
+      | isTrue# (i >=# n) = pure ()
+      | otherwise = k i *> go (i +# 1#)
+{-# INLINE forN_ #-}
+
+-- | Like 'forN_', but passes a type-safe 'Index' at each step.
+forIndices_ ::
+  Applicative m =>
+  Int# ->
+  (forall tp. Index ctx tp -> m ()) ->
+  m ()
+forIndices_ n k =
+  -- SAFETY: offsets are in @[0, n)@, matching positions in @ctx@.
+  forN_ n (\i -> k (unsafeMakeIndex (I# i)))
+{-# INLINE forIndices_ #-}
+
+-- | Right-fold over the elements of a frozen array.
+foldrArr :: (f Any -> b -> b) -> b -> Exts.SmallArray# (f Any) -> b
+foldrArr h = ifoldrArr (\_ x -> h x)
+{-# INLINE foldrArr #-}
+
+-- | Right-fold over a frozen array with the element's integer offset.
+ifoldrArr :: (Int -> f Any -> b -> b) -> b -> Exts.SmallArray# (f Any) -> b
+ifoldrArr h z arr = go 0#
+  where
+    n = size# arr
+    go i
+      | isTrue# (i >=# n) = z
+      | otherwise = h (I# i) (index# arr i) (go (i +# 1#))
+{-# INLINE ifoldrArr #-}
+
+-- | Right-fold over a frozen array with a type-safe 'Index' and the
+-- element coerced to match.
+foldrArrWithIndex ::
+  (forall tp. Index ctx tp -> f tp -> b -> b) ->
+  b ->
+  Exts.SmallArray# (f Any) ->
+  b
+foldrArrWithIndex h =
+  -- SAFETY: slot @i@ was written as @f tp@ for the @tp@ at position
+  -- @i@ in @ctx@; the 'Index' witnesses that @tp@.
+  ifoldrArr (\i x -> h (unsafeMakeIndex i) (unsafeFromAny x))
+{-# INLINE foldrArrWithIndex #-}
+
+-- | Strict left-fold over the elements of a frozen array.
+foldlArr' :: (b -> f Any -> b) -> b -> Exts.SmallArray# (f Any) -> b
+foldlArr' h z0 arr = go 0# z0
+  where
+    n = size# arr
+    go i !z
+      | isTrue# (i >=# n) = z
+      | otherwise = go (i +# 1#) (h z (index# arr i))
+{-# INLINE foldlArr' #-}
+
+-- | Build a 'SmallArrayF' of the given size by writing the given list
+-- of values in order.  The list must have exactly @n@ elements;
+-- shorter lists leave trailing slots as thunks that throw when read,
+-- and longer lists are truncated, so callers must ensure the length
+-- matches.
+unsafeFromListN# :: Int# -> [f Any] -> SmallArrayF f ctx
+unsafeFromListN# n ys0 = runST $ do
+  mut <- newMut# n
+  let loop _ []     = pure ()
+      loop i (y:yt) = writeMut# mut i y *> loop (i +# 1#) yt
+  loop 0# ys0
+  freezeMut mut
+{-# INLINE unsafeFromListN# #-}
+
+unsafeFromListN :: Int -> [f Any] -> SmallArrayF f ctx
+unsafeFromListN (I# n) = unsafeFromListN# n
+{-# INLINE unsafeFromListN #-}
+
+------------------------------------------------------------------------
+-- Payload coercions
+--
+-- The array stores values as @f Any@. Callers that supply a concrete
+-- @tp@ via an @Index ctx tp@ recover the real type via these coercions.
+-- The type role @nominal nominal@ on 'SmallArrayF' prevents users from
+-- conflating different @f@s or @ctx@s via 'coerce'.
+
+toAny :: f tp -> f Any
+toAny = unsafeCoerce
+{-# INLINE toAny #-}
+
+unsafeFromAny :: f Any -> f tp
+unsafeFromAny = unsafeCoerce
+{-# INLINE unsafeFromAny #-}
+
+
+------------------------------------------------------------------------
+-- Construction
+
+-- | \(O(1)\).  The empty container.
+empty :: SmallArrayF f EmptyCtx
+empty = runST $ do
+  mut <- newMut# 0#
+  freezeMut mut
+
+-- | \(O(1)\).  A container with a single element.
+singleton :: f tp -> SmallArrayF f (EmptyCtx ::> tp)
+singleton x = runST $ do
+  mut <- newMut# 1#
+  writeMut# mut 0# (toAny x)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with two elements.
+from2 ::
+  f t0 ->
+  f t1 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1)
+from2 x0 x1 = runST $ do
+  mut <- newMut# 2#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with three elements.
+from3 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2)
+from3 x0 x1 x2 = runST $ do
+  mut <- newMut# 3#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with four elements.
+from4 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  f t3 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2 ::> t3)
+from4 x0 x1 x2 x3 = runST $ do
+  mut <- newMut# 4#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  writeMut# mut 3# (toAny x3)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with five elements.
+from5 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  f t3 ->
+  f t4 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2 ::> t3 ::> t4)
+from5 x0 x1 x2 x3 x4 = runST $ do
+  mut <- newMut# 5#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  writeMut# mut 3# (toAny x3)
+  writeMut# mut 4# (toAny x4)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with six elements.
+from6 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  f t3 ->
+  f t4 ->
+  f t5 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2 ::> t3 ::> t4 ::> t5)
+from6 x0 x1 x2 x3 x4 x5 = runST $ do
+  mut <- newMut# 6#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  writeMut# mut 3# (toAny x3)
+  writeMut# mut 4# (toAny x4)
+  writeMut# mut 5# (toAny x5)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with seven elements.
+from7 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  f t3 ->
+  f t4 ->
+  f t5 ->
+  f t6 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2 ::> t3 ::> t4 ::> t5 ::> t6)
+from7 x0 x1 x2 x3 x4 x5 x6 = runST $ do
+  mut <- newMut# 7#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  writeMut# mut 3# (toAny x3)
+  writeMut# mut 4# (toAny x4)
+  writeMut# mut 5# (toAny x5)
+  writeMut# mut 6# (toAny x6)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with eight elements.
+from8 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  f t3 ->
+  f t4 ->
+  f t5 ->
+  f t6 ->
+  f t7 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2 ::> t3 ::> t4 ::> t5 ::> t6 ::> t7)
+from8 x0 x1 x2 x3 x4 x5 x6 x7 = runST $ do
+  mut <- newMut# 8#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  writeMut# mut 3# (toAny x3)
+  writeMut# mut 4# (toAny x4)
+  writeMut# mut 5# (toAny x5)
+  writeMut# mut 6# (toAny x6)
+  writeMut# mut 7# (toAny x7)
+  freezeMut mut
+
+-- | \(O(1)\).  A container with nine elements.
+from9 ::
+  f t0 ->
+  f t1 ->
+  f t2 ->
+  f t3 ->
+  f t4 ->
+  f t5 ->
+  f t6 ->
+  f t7 ->
+  f t8 ->
+  SmallArrayF f (EmptyCtx ::> t0 ::> t1 ::> t2 ::> t3 ::> t4 ::> t5 ::> t6 ::> t7 ::> t8)
+from9 x0 x1 x2 x3 x4 x5 x6 x7 x8 = runST $ do
+  mut <- newMut# 9#
+  writeMut# mut 0# (toAny x0)
+  writeMut# mut 1# (toAny x1)
+  writeMut# mut 2# (toAny x2)
+  writeMut# mut 3# (toAny x3)
+  writeMut# mut 4# (toAny x4)
+  writeMut# mut 5# (toAny x5)
+  writeMut# mut 6# (toAny x6)
+  writeMut# mut 7# (toAny x7)
+  writeMut# mut 8# (toAny x8)
+  freezeMut mut
+
+-- | \(O(n)\).  Build a 'SmallArrayF' by applying the supplied function
+-- at each index.
+generate ::
+  forall k (f :: k -> Type) (ctx :: Ctx k).
+  Size ctx ->
+  (forall tp. Index ctx tp -> f tp) ->
+  SmallArrayF f ctx
+generate sz fn = runST $ do
+  let !(I# n) = Ctx.sizeInt sz
+  mut <- newMut# n
+  forIndices_ n $ \idx ->
+    let !(I# i#) = Ctx.indexVal idx
+    in writeMut# mut i# (toAny (fn idx))
+  freezeMut mut
+{-# INLINE generate #-}
+
+-- | \(O(n)\) plus the cost of the @f@-actions.  Build a 'SmallArrayF'
+-- effectfully under an 'Applicative' constraint.
+generateA ::
+  forall k (f :: k -> Type) (ctx :: Ctx k) m.
+  Applicative m =>
+  Size ctx ->
+  (forall tp. Index ctx tp -> m (f tp)) ->
+  m (SmallArrayF f ctx)
+generateA sz fn = unsafeFromListN (Ctx.sizeInt sz) <$> xs
+  where
+    xs :: m [f Any]
+    xs = Ctx.forIndexRange 0 sz step (pure [])
+      where
+        step :: Index ctx tp -> m [f Any] -> m [f Any]
+        step idx rest = (:) <$> (toAny <$> fn idx) <*> rest
+{-# INLINE [1] generateA #-}
+
+{-# RULES "generateA/Identity"
+    forall sz (fn :: forall tp. Index ctx tp -> Identity (f tp)).
+    generateA sz fn = Identity (generate sz (runIdentity . fn)) #-}
+
+-- | \(O(n)\) plus the cost of the @f@-actions.  Build a 'SmallArrayF'
+-- in 'ST'.
+--
+-- Unlike 'generateA', this writes each result directly into the
+-- target array as it is produced, so no intermediate list is
+-- allocated.
+generateST ::
+  forall k (f :: k -> Type) (ctx :: Ctx k) s.
+  Size ctx ->
+  (forall tp. Index ctx tp -> ST s (f tp)) ->
+  ST s (SmallArrayF f ctx)
+generateST sz fn = do
+  let !(I# n) = Ctx.sizeInt sz
+  mut <- newMut# n
+  forIndices_ n $ \idx -> do
+    x <- fn idx
+    let !(I# i#) = Ctx.indexVal idx
+    writeMut# mut i# (toAny x)
+  freezeMut mut
+{-# INLINE generateST #-}
+
+-- | \(O(n)\) plus the cost of the @f@-actions.  Build a 'SmallArrayF'
+-- in an 'IO'-based monad.
+generateIO ::
+  forall k (f :: k -> Type) (ctx :: Ctx k) m.
+  MonadIO m =>
+  Size ctx ->
+  (forall tp. Index ctx tp -> m (f tp)) ->
+  m (SmallArrayF f ctx)
+generateIO sz fn = do
+  let !(I# n) = Ctx.sizeInt sz
+  mut <- liftIO (stToIO (newMut# n))
+  forIndices_ n $ \idx -> do
+    x <- fn idx
+    let !(I# i#) = Ctx.indexVal idx
+    liftIO (stToIO (writeMut# mut i# (toAny x)))
+  liftIO (stToIO (freezeMut mut))
+{-# SPECIALIZE generateIO ::
+      Size ctx
+   -> (forall tp. Index ctx tp -> IO (f tp))
+   -> IO (SmallArrayF f ctx) #-}
+
+unsafeMakeIndex :: Int -> Index ctx tp
+unsafeMakeIndex = unsafeCoerce
+{-# INLINE unsafeMakeIndex #-}
+
+------------------------------------------------------------------------
+-- Size
+
+-- | \(O(1)\).  The number of elements in the container.
+size :: SmallArrayF f ctx -> Size ctx
+size (SmallArrayF arr) =
+  -- SAFETY: 'Size' is a newtype over 'Int' and the array length equals
+  -- the number of positions in @ctx@ by construction.
+  unsafeCoerce (I# (size# arr))
+{-# INLINE [1] size #-}
+
+------------------------------------------------------------------------
+-- Indexing
+
+-- | \(O(1)\).  @a ! i@ is the element at position @i@ in @a@.
+(!) :: SmallArrayF f ctx -> Index ctx tp -> f tp
+(!) (SmallArrayF arr) idx =
+  -- SAFETY: the slot at @indexVal idx@ was written as an @f tp@ when
+  -- the array was constructed, so coercing back to @f tp@ is sound.
+  let !(I# i#) = Ctx.indexVal idx
+  in unsafeFromAny (index# arr i#)
+{-# INLINE (!) #-}
+
+infixl 9 !
+
+------------------------------------------------------------------------
+-- Modification
+
+-- | \(O(n)\).  Replace the element at the given index.  Allocates a
+-- fresh array and copies all elements into it.
+update :: Index ctx tp -> f tp -> SmallArrayF f ctx -> SmallArrayF f ctx
+update idx x (SmallArrayF src) = runST $ do
+  let n = size# src
+      !(I# i#) = Ctx.indexVal idx
+  mut <- newMut# n
+  copyInto# src mut n
+  writeMut# mut i# (toAny x)
+  freezeMut mut
+
+-- | \(O(n)\).  Apply a function at the given index.  Allocates a fresh
+-- array (inherits the cost of 'update').
+adjust ::
+  (f tp -> f tp) ->
+  Index ctx tp ->
+  SmallArrayF f ctx ->
+  SmallArrayF f ctx
+adjust f idx a = runIdentity (adjustM (Identity . f) idx a)
+{-# INLINE adjust #-}
+
+-- | \(O(n)\) plus the cost of the @m@-action.  Apply an effectful
+-- function at the given index.  Allocates a fresh array (inherits the
+-- cost of 'update').
+adjustM ::
+  Functor m =>
+  (f tp -> m (f tp)) ->
+  Index ctx tp ->
+  SmallArrayF f ctx ->
+  m (SmallArrayF f ctx)
+adjustM f idx a = (\x -> update idx x a) <$> f (a ! idx)
+{-# INLINE adjustM #-}
+-- For 'adjust':
+{-# SPECIALIZE adjustM ::
+      (f tp -> Identity (f tp))
+   -> Index ctx tp
+   -> SmallArrayF f ctx
+   -> Identity (SmallArrayF f ctx) #-}
+
+-- | \(O(n)\).  Append a new element on the right.  Allocates a fresh
+-- array of size n+1.
+extend :: SmallArrayF f ctx -> f tp -> SmallArrayF f (ctx ::> tp)
+extend (SmallArrayF src) x = runST $ do
+  let n = size# src
+  mut <- newMut# (n +# 1#)
+  copyInto# src mut n
+  writeMut# mut n (toAny x)
+  freezeMut mut
+
+-- | \(O(n)\).  Split off the last element.  Allocates a fresh array of
+-- size @n - 1@.
+unextend :: SmallArrayF f (ctx ::> tp) -> (SmallArrayF f ctx, f tp)
+unextend (SmallArrayF arr) = runST $ do
+  let n = size# arr
+      m = n -# 1#
+  mut <- newMut# m
+  copyIntoAt# arr 0# mut 0# m
+  frozen <- freezeMut mut
+  -- SAFETY: the last slot was written as @f tp@ for the @tp@ witnessing
+  -- the @::> tp@ in the context; coercing back to that type is sound.
+  let lastElem = unsafeFromAny (index# arr m)
+  pure (frozen, lastElem)
+{-# INLINE unextend #-}
+
+------------------------------------------------------------------------
+-- Combine
+
+-- | \(O(n)\).  Combine two 'SmallArrayF's element-wise.  Allocates a
+-- fresh array of the same size.
+zipWithFC ::
+  (forall tp. f tp -> g tp -> h tp) ->
+  SmallArrayF f ctx ->
+  SmallArrayF g ctx ->
+  SmallArrayF h ctx
+zipWithFC fn (SmallArrayF xs) (SmallArrayF ys) = runST $ do
+  let n = size# xs
+  mut <- newMut# n
+  forN_ n $ \i ->
+    writeMut# mut i (toAny (fn (index# xs i) (index# ys i)))
+  freezeMut mut
+{-# INLINE zipWithFC #-}
+
+-- | \(O(n)\) plus the cost of the @m@-actions.  Combine two
+-- 'SmallArrayF's element-wise under an effectful combinator.
+zipWithMFC ::
+  Applicative m =>
+  (forall tp. f tp -> g tp -> m (h tp)) ->
+  SmallArrayF f ctx ->
+  SmallArrayF g ctx ->
+  m (SmallArrayF h ctx)
+zipWithMFC fn (SmallArrayF xs) (SmallArrayF ys) =
+  unsafeFromListN# n <$> go 0#
+  where
+    n = size# xs
+    go i
+      | isTrue# (i >=# n) = pure []
+      | otherwise =
+          (:) <$> (toAny <$> fn (index# xs i) (index# ys i)) <*> go (i +# 1#)
+{-# INLINE [1] zipWithMFC #-}
+{-# RULES "zipWithMFC/ST"
+    forall (fn :: forall tp. f tp -> g tp -> ST s (h tp)).
+    zipWithMFC fn = zipWithMFCST fn #-}
+{-# RULES "zipWithMFC/IO"
+    forall (fn :: forall tp. f tp -> g tp -> IO (h tp)).
+    zipWithMFC fn = zipWithMFCIO fn #-}
+
+-- | Like 'zipWithMFC' specialized to 'ST'.  Writes results directly
+-- into the output array with no intermediate list.
+zipWithMFCST ::
+  forall k (f :: k -> Type) (g :: k -> Type) (h :: k -> Type)
+           (ctx :: Ctx k) s.
+  (forall tp. f tp -> g tp -> ST s (h tp)) ->
+  SmallArrayF f ctx ->
+  SmallArrayF g ctx ->
+  ST s (SmallArrayF h ctx)
+zipWithMFCST fn (SmallArrayF xs) (SmallArrayF ys) = do
+  let n = size# xs
+  mut <- newMut# n
+  -- SAFETY: same-ctx arrays share the same tp at each slot.
+  forN_ n $ \i -> do
+    z <- fn (index# xs i) (index# ys i)
+    writeMut# mut i (toAny z)
+  freezeMut mut
+{-# INLINE zipWithMFCST #-}
+
+-- | Like 'zipWithMFC' specialized to 'MonadIO'.  Writes results
+-- directly into the output array with no intermediate list.
+zipWithMFCIO ::
+  forall k (f :: k -> Type) (g :: k -> Type) (h :: k -> Type)
+           (ctx :: Ctx k) m.
+  MonadIO m =>
+  (forall tp. f tp -> g tp -> m (h tp)) ->
+  SmallArrayF f ctx ->
+  SmallArrayF g ctx ->
+  m (SmallArrayF h ctx)
+zipWithMFCIO fn (SmallArrayF xs) (SmallArrayF ys) = do
+  let n = size# xs
+  mut <- liftIO (stToIO (newMut# n))
+  -- SAFETY: same-ctx arrays share the same tp at each slot.
+  forN_ n $ \i -> do
+    z <- fn (index# xs i) (index# ys i)
+    liftIO (stToIO (writeMut# mut i (toAny z)))
+  liftIO (stToIO (freezeMut mut))
+{-# INLINE zipWithMFCIO #-}
+{-# SPECIALIZE zipWithMFCIO ::
+      (forall tp. f tp -> g tp -> IO (h tp))
+   -> SmallArrayF f ctx
+   -> SmallArrayF g ctx
+   -> IO (SmallArrayF h ctx) #-}
+
+-- | \(O(n)\).  Concatenate two 'SmallArrayF's.  Allocates a fresh
+-- array of size @|ctx| + |ctx'|@.
+append ::
+  SmallArrayF f ctx ->
+  SmallArrayF f ctx' ->
+  SmallArrayF f (ctx <+> ctx')
+append (SmallArrayF xs) (SmallArrayF ys) = runST $ do
+  let nx = size# xs
+      ny = size# ys
+  mut <- newMut# (nx +# ny)
+  copyIntoAt# xs 0# mut 0# nx
+  copyIntoAt# ys 0# mut nx ny
+  freezeMut mut
+{-# INLINE [1] append #-}
+
+------------------------------------------------------------------------
+-- Subarray
+
+-- | \(O(n)\).  Return the first @|ctx|@ elements of a concatenated
+-- array, discarding the suffix.  Allocates a fresh array of size
+-- @|ctx|@.
+take ::
+  Size ctx ->
+  Size ctx' ->
+  SmallArrayF f (ctx <+> ctx') ->
+  SmallArrayF f ctx
+take szCtx _ (SmallArrayF arr) = runST $ do
+  let !(I# n) = Ctx.sizeInt szCtx
+  mut <- newMut# n
+  copyIntoAt# arr 0# mut 0# n
+  freezeMut mut
+{-# INLINE [1] take #-}
+{-# RULES "take/append"
+    forall (a :: SmallArrayF f ctx)
+           (b :: SmallArrayF f ctx').
+    take (size a) (size b) (append a b) = a #-}
+
+-- | \(O(n)\).  Return the last @|ctx'|@ elements of a concatenated
+-- array, discarding the prefix.  Allocates a fresh array of size
+-- @|ctx'|@.
+drop ::
+  Size ctx ->
+  Size ctx' ->
+  SmallArrayF f (ctx <+> ctx') ->
+  SmallArrayF f ctx'
+drop szCtx szCtx' (SmallArrayF arr) = runST $ do
+  let !(I# off) = Ctx.sizeInt szCtx
+      !(I# n) = Ctx.sizeInt szCtx'
+  mut <- newMut# n
+  copyIntoAt# arr off mut 0# n
+  freezeMut mut
+{-# INLINE [1] drop #-}
+{-# RULES "drop/append"
+    forall (a :: SmallArrayF f ctx)
+           (b :: SmallArrayF f ctx').
+    drop (size a) (size b) (append a b) = b #-}
+
+------------------------------------------------------------------------
+-- Conversion to/from Assignment
+
+-- | \(O(n)\).  Build a 'SmallArrayF' from an 'Assignment', copying
+-- element pointers into a fresh small array.
+fromAssignment :: Assignment f ctx -> SmallArrayF f ctx
+fromAssignment a = runST $ do
+  let !(I# n) = Ctx.sizeInt (Ctx.size a)
+  mut <- newMut# n
+  -- ifoldrFC visits each element once (O(n) total); indexVal gives the
+  -- write position without a second tree lookup.
+  ifoldrFC (\idx x rest ->
+              let !(I# i#) = Ctx.indexVal idx
+              in writeMut# mut i# (toAny x) >> rest)
+           (pure ())
+           a
+  freezeMut mut
+{-# INLINE [1] fromAssignment #-}
+{-# RULES "fromAssignment/toAssignment"
+    forall a. fromAssignment (toAssignment a) = a #-}
+
+-- | \(O(n)\).  Build an 'Assignment' from a 'SmallArrayF'.
+toAssignment :: SmallArrayF f ctx -> Assignment f ctx
+toAssignment a = Ctx.generate (size a) (a !)
+{-# INLINE [1] toAssignment #-}
+{-# RULES "toAssignment/fromAssignment"
+    forall a. toAssignment (fromAssignment a) = a #-}
+
+------------------------------------------------------------------------
+-- Instances
+
+-- | Forces each element to WHNF (matching 'Data.Primitive.SmallArray.SmallArray').
+-- Does not force the elements' contents.
+instance NFData (SmallArrayF f ctx) where
+  rnf (SmallArrayF arr) = foldlArr' (\() x -> x `seq` ()) () arr
+
+-- Out-of-line worker for 'fmapFC'; named so that RULES can target it.
+fmapFC_ ::
+  (forall tp. f tp -> g tp) ->
+  SmallArrayF f ctx ->
+  SmallArrayF g ctx
+fmapFC_ h (SmallArrayF arr) = runST $ do
+  let n = size# arr
+  mut <- newMut# n
+  forN_ n $ \i ->
+    writeMut# mut i (toAny (h (index# arr i)))
+  freezeMut mut
+{-# INLINE [1] fmapFC_ #-}
+{-# RULES "fmapFC_/id"
+    forall arr.
+    fmapFC_ (\x -> x) arr = arr #-}
+{-# RULES "fmapFC_/fmapFC_"
+    forall (h :: forall tp. g tp -> k tp)
+           (g :: forall tp. f tp -> g tp)
+           arr.
+    fmapFC_ h (fmapFC_ g arr) = fmapFC_ (h . g) arr #-}
+{-# RULES "fmapFC_/imapFC_"
+    forall (h :: forall tp. g tp -> k tp)
+           (g :: forall tp. Index ctx tp -> f tp -> g tp)
+           arr.
+    fmapFC_ h (imapFC_ g arr) = imapFC_ (\idx -> h . g idx) arr #-}
+
+instance FunctorFC SmallArrayF where
+  -- GHC 9.0-9.2 reject the pointfree form due to higher-rank
+  -- polymorphism issues; on later GHCs we keep it pointfree so RULES
+  -- targeting 'fmapFC_' can match on the method's LHS.
+#if __GLASGOW_HASKELL__ < 904
+  fmapFC h arr = fmapFC_ h arr
+#else
+  fmapFC = fmapFC_
+#endif
+  {-# INLINE fmapFC #-}
+
+instance FoldableFC SmallArrayF where
+  foldrFC h z (SmallArrayF arr) = foldrArr h z arr
+  {-# INLINE foldrFC #-}
+
+  foldlFC' h z0 (SmallArrayF arr) = foldlArr' h z0 arr
+  {-# INLINE foldlFC' #-}
+
+-- Out-of-line worker for 'traverseFC'; named so that RULES can target it.
+traverseFC__ ::
+  Applicative m =>
+  (forall tp. f tp -> m (g tp)) ->
+  SmallArrayF f ctx ->
+  m (SmallArrayF g ctx)
+traverseFC__ h (SmallArrayF arr) =
+  unsafeFromListN# (size# arr)
+    <$> foldrArr (\x rest -> (:) <$> h x <*> rest) (pure []) arr
+{-# INLINE [1] traverseFC__ #-}
+{-# RULES "traverseFC/ST"
+    forall (h :: forall tp. f tp -> ST s (g tp)).
+    traverseFC__ h = traverseFCST h #-}
+{-# RULES "traverseFC/IO"
+    forall (h :: forall tp. f tp -> IO (g tp)).
+    traverseFC__ h = traverseFCIO h #-}
+{-# RULES "traverseFC/fmapFC_"
+    forall (h :: forall tp. g tp -> m (k tp))
+           (g :: forall tp. f tp -> g tp)
+           arr.
+    traverseFC__ h (fmapFC_ g arr) = traverseFC__ (h . g) arr #-}
+
+instance TraversableFC SmallArrayF where
+#if __GLASGOW_HASKELL__ < 904
+  traverseFC h arr = traverseFC__ h arr
+#else
+  traverseFC = traverseFC__
+#endif
+  {-# INLINE traverseFC #-}
+
+type instance IndexF   (SmallArrayF f ctx) = Index ctx
+type instance IxValueF (SmallArrayF f ctx) = f
+
+instance forall k (f :: k -> Type) ctx. IxedF k (SmallArrayF f ctx) where
+  ixF :: Index ctx x -> Lens.Traversal' (SmallArrayF f ctx) (f x)
+  ixF idx f = adjustM f idx
+
+instance forall k (f :: k -> Type) ctx. IxedF' k (SmallArrayF f ctx) where
+  ixF' :: Index ctx x -> Lens.Lens' (SmallArrayF f ctx) (f x)
+  ixF' idx f = adjustM f idx
+
+-- Out-of-line worker for 'imapFC'; named so that RULES can target it.
+imapFC_ ::
+  (forall tp. Index ctx tp -> f tp -> g tp) ->
+  SmallArrayF f ctx ->
+  SmallArrayF g ctx
+imapFC_ h (SmallArrayF arr) = runST $ do
+  let n = size# arr
+  mut <- newMut# n
+  -- SAFETY: slot @i@ was written as @f tp@ for the @tp@ witnessed by @idx@.
+  forIndices_ n $ \idx ->
+    let !(I# i#) = Ctx.indexVal idx
+    in writeMut# mut i# (toAny (h idx (unsafeFromAny (index# arr i#))))
+  freezeMut mut
+{-# INLINE [1] imapFC_ #-}
+{-# RULES "imapFC_/fmapFC_"
+    forall (h :: forall tp. Index ctx tp -> g tp -> k tp)
+           (g :: forall tp. f tp -> g tp)
+           arr.
+    imapFC_ h (fmapFC_ g arr) = imapFC_ (\idx -> h idx . g) arr #-}
+{-# RULES "imapFC_/imapFC_"
+    forall (h :: forall tp. Index ctx tp -> g tp -> k tp)
+           (g :: forall tp. Index ctx tp -> f tp -> g tp)
+           arr.
+    imapFC_ h (imapFC_ g arr) = imapFC_ (\idx -> h idx . g idx) arr #-}
+
+instance FunctorFCWithIndex SmallArrayF where
+#if __GLASGOW_HASKELL__ < 904
+  imapFC h arr = imapFC_ h arr
+#else
+  imapFC = imapFC_
+#endif
+  {-# INLINE imapFC #-}
+
+instance FoldableFCWithIndex SmallArrayF where
+  ifoldrFC h z (SmallArrayF arr) = foldrArrWithIndex h z arr
+  {-# INLINE ifoldrFC #-}
+
+-- Out-of-line worker for 'itraverseFC'; named so that RULES can target it.
+itraverseFC__ ::
+  Applicative m =>
+  (forall tp. Index ctx tp -> f tp -> m (g tp)) ->
+  SmallArrayF f ctx ->
+  m (SmallArrayF g ctx)
+itraverseFC__ h (SmallArrayF arr) =
+  unsafeFromListN# (size# arr)
+    <$> foldrArrWithIndex
+          (\idx x rest -> (:) <$> (toAny <$> h idx x) <*> rest)
+          (pure [])
+          arr
+{-# INLINE [1] itraverseFC__ #-}
+{-# RULES "itraverseFC/ST"
+    forall (h :: forall tp. Index ctx tp -> f tp -> ST s (g tp)).
+    itraverseFC__ h = itraverseFCST h #-}
+{-# RULES "itraverseFC/IO"
+    forall (h :: forall tp. Index ctx tp -> f tp -> IO (g tp)).
+    itraverseFC__ h = itraverseFCIO h #-}
+{-# RULES "itraverseFC/fmapFC_"
+    forall (h :: forall tp. Index ctx tp -> g tp -> m (k tp))
+           (g :: forall tp. f tp -> g tp)
+           arr.
+    itraverseFC__ h (fmapFC_ g arr) = itraverseFC__ (\idx -> h idx . g) arr #-}
+{-# RULES "itraverseFC/imapFC_"
+    forall (h :: forall tp. Index ctx tp -> g tp -> m (k tp))
+           (g :: forall tp. Index ctx tp -> f tp -> g tp)
+           arr.
+    itraverseFC__ h (imapFC_ g arr) = itraverseFC__ (\idx -> h idx . g idx) arr #-}
+
+instance TraversableFCWithIndex SmallArrayF where
+#if __GLASGOW_HASKELL__ < 904
+  itraverseFC h arr = itraverseFC__ h arr
+#else
+  itraverseFC = itraverseFC__
+#endif
+  {-# INLINE itraverseFC #-}
+
+------------------------------------------------------------------------
+-- ST- and IO-specialised traversals
+
+-- | Like 'traverseFC' specialised to 'ST'.  Writes each result
+-- directly into the output array with no intermediate list.
+traverseFCST ::
+  forall k (f :: k -> Type) (g :: k -> Type) (ctx :: Ctx k) s.
+  (forall tp. f tp -> ST s (g tp)) ->
+  SmallArrayF f ctx ->
+  ST s (SmallArrayF g ctx)
+traverseFCST h (SmallArrayF arr) = do
+  let n = size# arr
+  mut <- newMut# n
+  forN_ n $ \i -> do
+    y <- h (index# arr i)
+    writeMut# mut i (toAny y)
+  freezeMut mut
+{-# INLINE traverseFCST #-}
+
+-- | Like 'traverseFC' specialised to 'MonadIO'.  Writes each result
+-- directly into the output array with no intermediate list.
+traverseFCIO ::
+  forall k (f :: k -> Type) (g :: k -> Type) (ctx :: Ctx k) m.
+  MonadIO m =>
+  (forall tp. f tp -> m (g tp)) ->
+  SmallArrayF f ctx ->
+  m (SmallArrayF g ctx)
+traverseFCIO h (SmallArrayF arr) = do
+  let n = size# arr
+  mut <- liftIO (stToIO (newMut# n))
+  forN_ n $ \i -> do
+    y <- h (index# arr i)
+    liftIO (stToIO (writeMut# mut i (toAny y)))
+  liftIO (stToIO (freezeMut mut))
+{-# INLINE traverseFCIO #-}
+{-# SPECIALIZE traverseFCIO ::
+      (forall tp. f tp -> IO (g tp))
+   -> SmallArrayF f ctx
+   -> IO (SmallArrayF g ctx) #-}
+
+-- | Like 'itraverseFC' specialised to 'ST'.  Writes each result
+-- directly into the output array with no intermediate list.
+itraverseFCST ::
+  forall k (f :: k -> Type) (g :: k -> Type) (ctx :: Ctx k) s.
+  (forall tp. Index ctx tp -> f tp -> ST s (g tp)) ->
+  SmallArrayF f ctx ->
+  ST s (SmallArrayF g ctx)
+itraverseFCST h (SmallArrayF arr) = do
+  let n = size# arr
+  mut <- newMut# n
+  -- SAFETY: slot i was written as f tp for the tp witnessed by idx.
+  forIndices_ n $ \idx ->
+    let !(I# i#) = Ctx.indexVal idx
+    in do
+      y <- h idx (unsafeFromAny (index# arr i#))
+      writeMut# mut i# (toAny y)
+  freezeMut mut
+{-# INLINE itraverseFCST #-}
+
+-- | Like 'itraverseFC' specialised to 'MonadIO'.  Writes each result
+-- directly into the output array with no intermediate list.
+itraverseFCIO ::
+  forall k (f :: k -> Type) (g :: k -> Type) (ctx :: Ctx k) m.
+  MonadIO m =>
+  (forall tp. Index ctx tp -> f tp -> m (g tp)) ->
+  SmallArrayF f ctx ->
+  m (SmallArrayF g ctx)
+itraverseFCIO h (SmallArrayF arr) = do
+  let n = size# arr
+  mut <- liftIO (stToIO (newMut# n))
+  -- SAFETY: slot i was written as f tp for the tp witnessed by idx.
+  forIndices_ n $ \idx ->
+    let !(I# i#) = Ctx.indexVal idx
+    in do
+      y <- h idx (unsafeFromAny (index# arr i#))
+      liftIO (stToIO (writeMut# mut i# (toAny y)))
+  liftIO (stToIO (freezeMut mut))
+{-# INLINE itraverseFCIO #-}
+{-# SPECIALIZE itraverseFCIO ::
+      (forall tp. Index ctx tp -> f tp -> IO (g tp))
+   -> SmallArrayF f ctx
+   -> IO (SmallArrayF g ctx) #-}
+
+instance TestEqualityFC SmallArrayF where
+  testEqualityFC eqElt (SmallArrayF x) (SmallArrayF y)
+    | isTrue# (nx /=# ny) = Nothing
+    | otherwise = go 0#
+    where
+      nx = size# x
+      ny = size# y
+      go i
+        -- SAFETY: both arrays have the same length and all pairs of elements
+        -- have been shown equal, so their contexts must agree.
+        | isTrue# (i >=# nx) = Just unsafeAxiom
+        | otherwise =
+            case eqElt (index# x i) (index# y i) of
+              Just _ -> go (i +# 1#)
+              Nothing -> Nothing
+
+instance OrdFC SmallArrayF where
+  compareFC cmpElt (SmallArrayF x) (SmallArrayF y) =
+    case compare (I# (size# x)) (I# (size# y)) of
+      LT -> LTF
+      GT -> GTF
+      EQ -> go 0#
+    where
+      n = size# x
+      go i
+        -- SAFETY: sizes match and all pairs compare 'EQF', so the contexts
+        -- agree; 'EQF' requires that witness.
+        | isTrue# (i >=# n) = unsafeCoerce EQF
+        | otherwise =
+            case cmpElt (index# x i) (index# y i) of
+              LTF -> LTF
+              GTF -> GTF
+              EQF -> go (i +# 1#)
+
+instance TestEquality f => TestEquality (SmallArrayF f) where
+  testEquality = testEqualityFC testEquality
+
+instance TestEquality f => Eq (SmallArrayF f ctx) where
+  x == y = isJust (testEquality x y)
+
+instance OrdF f => OrdF (SmallArrayF f) where
+  compareF = compareFC compareF
+
+instance OrdF f => Ord (SmallArrayF f ctx) where
+  compare x y = toOrdering (compareF x y)
+
+instance ShowF f => Show (SmallArrayF f ctx) where
+  show a =
+    let xs = foldrFC (\e r -> showF e : r) [] a
+    in "[" ++ intercalate ", " xs ++ "]"
+
+instance ShowF f => ShowF (SmallArrayF f)
+
+instance (HashableF f, TestEquality f) => Hashable (SmallArrayF f ctx) where
+  hashWithSalt s a = foldlFC' hashWithSaltF s a
+
+instance (HashableF f, TestEquality f) => HashableF (SmallArrayF f) where
+  hashWithSaltF = hashWithSalt
+

--- a/test/Test/SmallArrayF.hs
+++ b/test/Test/SmallArrayF.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.SmallArrayF
+  ( smallArrayFTests
+  ) where
+
+import           Data.Functor.Identity (Identity(Identity, runIdentity))
+import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Parameterized.SmallArrayF as SAF
+import           Data.Parameterized.Some
+import           Data.Parameterized.TraversableFC
+import           Data.Parameterized.TraversableFC.WithIndex
+import           Hedgehog
+import qualified Hedgehog.Gen as HG
+import           Hedgehog.Range (linear)
+import qualified Test.Tasty as TT
+import           Test.Tasty.Hedgehog
+
+import           Test.Context (genSomePayloadList)
+
+----------------------------------------------------------------------
+-- Helpers
+
+-- Build a SmallArrayF from a list of Some values by going through
+-- Assignment.
+mkSAF :: [Some f] -> Some (SAF.SmallArrayF f)
+mkSAF vals =
+  case go Ctx.empty vals of
+    Some a -> Some (SAF.fromAssignment a)
+  where
+    go :: Ctx.Assignment f ctx -> [Some f] -> Some (Ctx.Assignment f)
+    go acc []            = Some acc
+    go acc (Some x : xs) = go (Ctx.extend acc x) xs
+
+----------------------------------------------------------------------
+-- Properties
+
+prop_size :: Property
+prop_size = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  length vals === Ctx.sizeInt (SAF.size a)
+
+prop_indexEq :: Property
+prop_indexEq = property $ do
+  vals <- forAll genSomePayloadList
+  i    <- forAll $ HG.int (linear 0 (length vals - 1))
+  Some a <- return $ mkSAF vals
+  Just (Some idx) <- return $ Ctx.intIndex i (SAF.size a)
+  Some (a SAF.! idx) === vals !! i
+
+prop_toListFC :: Property
+prop_toListFC = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  vals === toListFC Some a
+
+prop_updateRoundtrip :: Property
+prop_updateRoundtrip = property $ do
+  vals <- forAll genSomePayloadList
+  i    <- forAll $ HG.int (linear 0 (length vals - 1))
+  Some a <- return $ mkSAF vals
+  Just (Some idx) <- return $ Ctx.intIndex i (SAF.size a)
+  let old = a SAF.! idx
+      a'  = SAF.update idx old a
+  toListFC Some a === toListFC Some a'
+
+prop_generateIndexConsistent :: Property
+prop_generateIndexConsistent = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  let a' = SAF.generate (SAF.size a) (a SAF.!)
+  toListFC Some a === toListFC Some a'
+
+prop_extendSize :: Property
+prop_extendSize = property $ do
+  vals <- forAll genSomePayloadList
+  -- Take first element of vals (guaranteed non-empty) and reuse it so
+  -- we don't need a second generator.
+  case vals of
+    []         -> error "genSomePayloadList produced empty list"
+    Some v : _ -> do
+      Some a <- return $ mkSAF vals
+      let a'  = SAF.extend a v
+          lst = toListFC Some a'
+      length lst === length vals + 1
+
+prop_traverseFCIdentity :: Property
+prop_traverseFCIdentity = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  let a' = runIdentity (traverseFC Identity a)
+  toListFC Some a === toListFC Some a'
+
+prop_foldMapFCList :: Property
+prop_foldMapFCList = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  vals === foldMapFC (\x -> [Some x]) a
+
+prop_agreesWithAssignment :: Property
+prop_agreesWithAssignment = property $ do
+  vals <- forAll genSomePayloadList
+  i    <- forAll $ HG.int (linear 0 (length vals - 1))
+  Some a <- return $ mkSAF vals
+  let asgn = SAF.toAssignment a
+  Just (Some idx) <- return $ Ctx.intIndex i (SAF.size a)
+  Some (a SAF.! idx) === Some (asgn Ctx.! idx)
+
+prop_imapFCConstFmap :: Property
+prop_imapFCConstFmap = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  toListFC Some (imapFC (\_ x -> x) a) === toListFC Some a
+
+prop_itraverseFCAgreesWithItoList :: Property
+prop_itraverseFCAgreesWithItoList = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  let viaTraverse = runIdentity (itraverseFC (\_ x -> Identity x) a)
+  toListFC Some viaTraverse === toListFC Some a
+
+prop_ifoldMapFCFoldMapFC :: Property
+prop_ifoldMapFCFoldMapFC = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  foldMapFC (\x -> [Some x]) a === ifoldMapFC (\_ x -> [Some x]) a
+
+-- zipWithFC id is fmapFC (given equal inputs)
+prop_zipWithFCDiag :: Property
+prop_zipWithFCDiag = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  toListFC Some (SAF.zipWithFC (\x _ -> x) a a) === toListFC Some a
+
+-- zipWithMFC with Identity agrees with zipWithFC
+prop_zipWithMFCAgreesWithZipWithFC :: Property
+prop_zipWithMFCAgreesWithZipWithFC = property $ do
+  vals <- forAll genSomePayloadList
+  Some a <- return $ mkSAF vals
+  let pure' = SAF.zipWithFC (\x _ -> x) a a
+      eff   = runIdentity (SAF.zipWithMFC (\x _ -> Identity x) a a)
+  toListFC Some pure' === toListFC Some eff
+
+-- append produces the concatenation of both element lists
+prop_appendConcat :: Property
+prop_appendConcat = property $ do
+  xs <- forAll genSomePayloadList
+  ys <- forAll genSomePayloadList
+  Some a <- return $ mkSAF xs
+  Some b <- return $ mkSAF ys
+  toListFC Some (SAF.append a b) === (xs ++ ys)
+
+-- unextend is the inverse of extend
+prop_unextendExtend :: Property
+prop_unextendExtend = property $ do
+  vals <- forAll genSomePayloadList
+  Some v : _ <- return vals
+  Some a <- return $ mkSAF vals
+  let a' = SAF.extend a v
+      (a'', v') = SAF.unextend a'
+  toListFC Some a === toListFC Some a''
+  Some v === Some v'
+
+-- take and drop partition append
+prop_takeDropPartition :: Property
+prop_takeDropPartition = property $ do
+  xs <- forAll genSomePayloadList
+  ys <- forAll genSomePayloadList
+  Some a <- return $ mkSAF xs
+  Some b <- return $ mkSAF ys
+  let ab = SAF.append a b
+      sa = SAF.size a
+      sb = SAF.size b
+  toListFC Some (SAF.take sa sb ab) ++ toListFC Some (SAF.drop sa sb ab)
+    === toListFC Some ab
+
+----------------------------------------------------------------------
+
+smallArrayFTests :: IO TT.TestTree
+smallArrayFTests = return $ TT.testGroup "SmallArrayF"
+  [ testPropertyNamed "size" "prop_size" prop_size
+  , testPropertyNamed "index_eq" "prop_indexEq" prop_indexEq
+  , testPropertyNamed "toListFC" "prop_toListFC" prop_toListFC
+  , testPropertyNamed "update_roundtrip" "prop_updateRoundtrip" prop_updateRoundtrip
+  , testPropertyNamed "generate_index_consistent" "prop_generateIndexConsistent" prop_generateIndexConsistent
+  , testPropertyNamed "extend_size" "prop_extendSize" prop_extendSize
+  , testPropertyNamed "traverseFC_identity" "prop_traverseFCIdentity" prop_traverseFCIdentity
+  , testPropertyNamed "foldMapFC_list" "prop_foldMapFCList" prop_foldMapFCList
+  , testPropertyNamed "agrees_with_assignment" "prop_agreesWithAssignment" prop_agreesWithAssignment
+  , testPropertyNamed "imapFC_const_fmap" "prop_imapFCConstFmap" prop_imapFCConstFmap
+  , testPropertyNamed "itraverseFC_identity" "prop_itraverseFCAgreesWithItoList" prop_itraverseFCAgreesWithItoList
+  , testPropertyNamed "ifoldMapFC_foldMapFC" "prop_ifoldMapFCFoldMapFC" prop_ifoldMapFCFoldMapFC
+  , testPropertyNamed "zipWithFC_diag" "prop_zipWithFCDiag" prop_zipWithFCDiag
+  , testPropertyNamed "zipWithMFC_agrees_zipWithFC" "prop_zipWithMFCAgreesWithZipWithFC" prop_zipWithMFCAgreesWithZipWithFC
+  , testPropertyNamed "append_concat" "prop_appendConcat" prop_appendConcat
+  , testPropertyNamed "unextend_extend" "prop_unextendExtend" prop_unextendExtend
+  , testPropertyNamed "take_drop_partition" "prop_takeDropPartition" prop_takeDropPartition
+  ]

--- a/test/Test/SmallArrayF/Instances.hs
+++ b/test/Test/SmallArrayF/Instances.hs
@@ -1,0 +1,225 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Typeclass-laws tests for 'SmallArrayF' instances.
+--
+-- Uses @hedgehog-classes@ for the base laws, with a generator that
+-- produces existentially-wrapped arrays of varying length and
+-- contents; 'Some''s 'Eq' / 'Ord' / 'Show' / 'Hashable' instances
+-- already delegate to the parameterized instances on 'SmallArrayF'.
+-- The 'FunctorFC' / 'FoldableFC' / 'TraversableFC' laws are
+-- hand-written Hedgehog properties, since @hedgehog-classes@ does not
+-- cover those classes.
+module Test.SmallArrayF.Instances (tests) where
+
+import Control.DeepSeq (NFData(rnf))
+import Data.Functor.Identity (Identity(Identity, runIdentity))
+import Data.Hashable (hashWithSalt)
+import Data.Kind (Type)
+import qualified Data.Parameterized.Context as Ctx
+import Data.Parameterized.Classes (HashableF(..), OrdF(..), OrderingF(..), ShowF, TestEquality(..), (:~:)(Refl))
+import qualified Data.Parameterized.SmallArrayF as SAF
+import Data.Parameterized.SmallArrayF (SmallArrayF)
+import Data.Parameterized.Some
+import Data.Parameterized.TraversableFC
+import Data.Parameterized.TraversableFC.WithIndex
+import Hedgehog
+import qualified Hedgehog.Classes as HC
+import qualified Hedgehog.Gen as HG
+import Hedgehog.Range (linear)
+import qualified Test.Tasty as TT
+import qualified Test.Tasty.HUnit as TTH
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+----------------------------------------------------------------------
+-- Payload: a GADT indexed by 'Ordering' or 'Bool', so 'TestEquality'
+-- and 'OrdF' can be written honestly (no unsafe coercions).
+
+data P (tp :: Type) where
+  PO :: Ordering -> P Ordering
+  PB :: Bool -> P Bool
+
+deriving instance Eq (P tp)
+deriving instance Ord (P tp)
+deriving instance Show (P tp)
+
+instance ShowF P
+
+instance TestEquality P where
+  testEquality (PO x) (PO y) = if x == y then Just Refl else Nothing
+  testEquality (PB x) (PB y) = if x == y then Just Refl else Nothing
+  testEquality _ _ = Nothing
+
+instance OrdF P where
+  compareF (PO x) (PO y) = case compare x y of
+    LT -> LTF
+    EQ -> EQF
+    GT -> GTF
+  compareF (PB x) (PB y) = case compare x y of
+    LT -> LTF
+    EQ -> EQF
+    GT -> GTF
+  compareF PO{} PB{} = LTF
+  compareF PB{} PO{} = GTF
+
+instance HashableF P where
+  hashWithSaltF s (PO o) = hashWithSalt s (0 :: Int, fromEnum o)
+  hashWithSaltF s (PB b) = hashWithSalt s (1 :: Int, b)
+
+----------------------------------------------------------------------
+-- Generators
+
+genP :: Gen (Some P)
+genP = HG.choice
+  [ Some . PO <$> HG.element [LT, EQ, GT]
+  , Some . PB <$> HG.element [True, False]
+  ]
+
+genPList :: Gen [Some P]
+genPList = HG.list (linear 0 8) genP
+
+mkArr :: [Some P] -> Some (SmallArrayF P)
+mkArr vals =
+  case go Ctx.empty vals of
+    Some a -> Some (SAF.fromAssignment a)
+  where
+    go :: Ctx.Assignment P ctx -> [Some P] -> Some (Ctx.Assignment P)
+    go acc [] = Some acc
+    go acc (Some x : xs) = go (Ctx.extend acc x) xs
+
+genSomeSA :: Gen (Some (SmallArrayF P))
+genSomeSA = mkArr <$> genPList
+
+showOf :: P tp -> String
+showOf (PO o) = "O " ++ show o
+showOf (PB b) = "B " ++ show b
+
+toListStr :: SmallArrayF P ctx -> [String]
+toListStr = foldrFC (\x r -> showOf x : r) []
+
+----------------------------------------------------------------------
+-- FunctorFC laws
+
+-- fmapFC id = id
+prop_fmapFC_identity :: Property
+prop_fmapFC_identity = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  toListStr (fmapFC id a) === toListStr a
+
+-- fmapFC (f . g) = fmapFC f . fmapFC g
+prop_fmapFC_composition :: Property
+prop_fmapFC_composition = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  toListStr (fmapFC (shift . flipOrd) a) === toListStr (fmapFC shift (fmapFC flipOrd a))
+
+-- Rotate 'LT → EQ → GT → LT'; identity elsewhere.
+shift :: P tp -> P tp
+shift (PO LT) = PO EQ
+shift (PO EQ) = PO GT
+shift (PO GT) = PO LT
+shift (PB b)  = PB b
+
+-- Flip 'LT <-> GT'; identity elsewhere.
+flipOrd :: P tp -> P tp
+flipOrd (PO LT) = PO GT
+flipOrd (PO GT) = PO LT
+flipOrd (PO EQ) = PO EQ
+flipOrd (PB b)  = PB (not b)
+
+----------------------------------------------------------------------
+-- FoldableFC laws
+
+-- foldMapFC f = foldrFC (mappend . f) mempty
+prop_foldMapFC_foldrFC :: Property
+prop_foldMapFC_foldrFC = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  let f x = [showOf x]
+  foldMapFC f a === foldrFC (mappend . f) mempty a
+
+----------------------------------------------------------------------
+-- TraversableFC laws
+
+-- traverseFC Identity = Identity
+prop_traverseFC_identity :: Property
+prop_traverseFC_identity = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  toListStr (runIdentity (traverseFC Identity a)) === toListStr a
+
+-- traverseFC (Identity . f) = Identity . fmapFC f
+prop_traverseFC_fmapFC :: Property
+prop_traverseFC_fmapFC = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  toListStr (runIdentity (traverseFC (Identity . shift) a)) === toListStr (fmapFC shift a)
+
+----------------------------------------------------------------------
+-- FunctorFCWithIndex / FoldableFCWithIndex laws
+
+-- imapFC (\_ x -> f x) = fmapFC f
+prop_imapFC_const_fmapFC :: Property
+prop_imapFC_const_fmapFC = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  toListStr (imapFC (\_ x -> shift x) a) === toListStr (fmapFC shift a)
+
+-- ifoldMapFC (\_ x -> f x) = foldMapFC f
+prop_ifoldMapFC_const_foldMapFC :: Property
+prop_ifoldMapFC_const_foldMapFC = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  let f x = [showOf x]
+  ifoldMapFC (\_ x -> f x) a === foldMapFC f a
+
+----------------------------------------------------------------------
+-- NFData: rnf terminates on random arrays.
+
+prop_rnf_total :: Property
+prop_rnf_total = property $ do
+  vals <- forAll genPList
+  Some a <- pure $ mkArr vals
+  rnf a === ()
+
+----------------------------------------------------------------------
+-- Test tree
+
+hcLawsCase :: String -> HC.Laws -> TT.TestTree
+hcLawsCase name laws =
+  TTH.testCase name $
+    TTH.assertBool name =<< HC.lawsCheck laws
+
+tests :: TT.TestTree
+tests = TT.testGroup "SmallArrayF instances"
+  [ TT.testGroup "hedgehog-classes"
+    [ hcLawsCase "Eq" (HC.eqLaws genSomeSA)
+    , hcLawsCase "Ord" (HC.ordLaws genSomeSA)
+    , hcLawsCase "Show" (HC.showLaws genSomeSA)
+    ]
+  , TT.testGroup "FunctorFC"
+    [ testPropertyNamed "identity" "prop_fmapFC_identity" prop_fmapFC_identity
+    , testPropertyNamed "composition" "prop_fmapFC_composition" prop_fmapFC_composition
+    ]
+  , TT.testGroup "FoldableFC"
+    [ testPropertyNamed "foldMapFC_via_foldrFC" "prop_foldMapFC_foldrFC" prop_foldMapFC_foldrFC
+    ]
+  , TT.testGroup "TraversableFC"
+    [ testPropertyNamed "identity" "prop_traverseFC_identity" prop_traverseFC_identity
+    , testPropertyNamed "fmapFC_agreement" "prop_traverseFC_fmapFC" prop_traverseFC_fmapFC
+    ]
+  , TT.testGroup "WithIndex"
+    [ testPropertyNamed "imapFC_const_fmapFC" "prop_imapFC_const_fmapFC" prop_imapFC_const_fmapFC
+    , testPropertyNamed "ifoldMapFC_const_foldMapFC" "prop_ifoldMapFC_const_foldMapFC" prop_ifoldMapFC_const_foldMapFC
+    ]
+  , TT.testGroup "NFData"
+    [ testPropertyNamed "rnf_total" "prop_rnf_total" prop_rnf_total
+    ]
+  ]

--- a/test/Test/SmallArrayF/Rules.hs
+++ b/test/Test/SmallArrayF/Rules.hs
@@ -1,0 +1,317 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- Compile at -O2 so all INLINE pragmas and RULES fire fully.
+-- Disable HPC ticks and worker-wrapper so LHS/RHS Core can be compared.
+{-# OPTIONS_GHC -O2 -fplugin=Test.Tasty.Inspection.Plugin -fno-hpc -fno-worker-wrapper #-}
+-- Several rules rely on simplifier/rewriter behavior that only matches
+-- LHS/RHS Core on GHC >= 9.8; on older GHCs we skip the whole suite.
+-- Semantic correctness is still covered by RulesSemantics.
+
+module Test.SmallArrayF.Rules (tests) where
+
+import qualified Test.Tasty as TT
+
+#if __GLASGOW_HASKELL__ >= 908
+
+import           Control.Monad.ST (ST)
+import           Data.Functor.Identity (Identity(Identity, runIdentity))
+import           Data.Kind (Type)
+import           Data.Parameterized.Context (Index)
+import qualified Data.Parameterized.SmallArrayF as SAF
+import           Data.Parameterized.SmallArrayF (SmallArrayF)
+import           Data.Parameterized.TraversableFC
+import           Data.Parameterized.TraversableFC.WithIndex
+import           Test.Tasty.Inspection
+
+import           Data.Parameterized.Ctx (EmptyCtx, type (::>))
+import qualified Data.Parameterized.Context as Ctx
+
+------------------------------------------------------------------------
+-- Payload type
+
+newtype V (tp :: Type) = V Int
+  deriving (Show, Eq)
+
+type Ctx3 = EmptyCtx ::> Int ::> Bool ::> Char
+
+------------------------------------------------------------------------
+-- NOINLINE element-level functions (so rules can still fire on the
+-- container combinators but the payloads don't get optimized away).
+
+{-# NOINLINE twiddle #-}
+twiddle :: V tp -> V tp
+twiddle (V n) = V (n + 1)
+
+{-# NOINLINE twaddle #-}
+twaddle :: V tp -> V tp
+twaddle (V n) = V (n * 2)
+
+{-# NOINLINE itwiddle #-}
+itwiddle :: Index ctx tp -> V tp -> V tp
+itwiddle idx (V n) = V (n + Ctx.indexVal idx)
+
+{-# NOINLINE itwaddle #-}
+itwaddle :: Index ctx tp -> V tp -> V tp
+itwaddle idx (V n) = V (n * (1 + Ctx.indexVal idx))
+
+{-# NOINLINE stTwiddle #-}
+stTwiddle :: V tp -> ST s (V tp)
+stTwiddle (V n) = pure (V (n + 1))
+
+{-# NOINLINE ioTwiddle #-}
+ioTwiddle :: V tp -> IO (V tp)
+ioTwiddle (V n) = pure (V (n + 1))
+
+{-# NOINLINE stZipFn #-}
+stZipFn :: V tp -> V tp -> ST s (V tp)
+stZipFn (V a) (V b) = pure (V (a + b))
+
+{-# NOINLINE ioZipFn #-}
+ioZipFn :: V tp -> V tp -> IO (V tp)
+ioZipFn (V a) (V b) = pure (V (a + b))
+
+{-# NOINLINE istTwiddle #-}
+istTwiddle :: Index ctx tp -> V tp -> ST s (V tp)
+istTwiddle idx (V n) = pure (V (n + Ctx.indexVal idx))
+
+{-# NOINLINE ioiTwiddle #-}
+ioiTwiddle :: Index ctx tp -> V tp -> IO (V tp)
+ioiTwiddle idx (V n) = pure (V (n + Ctx.indexVal idx))
+
+------------------------------------------------------------------------
+-- Fusion rules: fmapFC_/fmapFC_
+--
+-- After the rule fires, fmapFC twaddle (fmapFC twiddle arr) becomes
+-- fmapFC (twaddle . twiddle) arr — a single pass.  We verify this by
+-- checking that the two-pass version compiles to the same Core as the
+-- single-pass version.  NOINLINE prevents worker-wrapper from creating
+-- differently-named wrappers that defeat the comparison.
+
+{-# NOINLINE lhs_fmapFC_fmapFC #-}
+lhs_fmapFC_fmapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_fmapFC_fmapFC arr = fmapFC twaddle (fmapFC twiddle arr)
+
+{-# NOINLINE rhs_fmapFC_fmapFC #-}
+rhs_fmapFC_fmapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_fmapFC_fmapFC arr = fmapFC (twaddle . twiddle) arr
+
+-- Fusion rules: traverseFC/fmapFC_
+
+{-# NOINLINE lhs_traverseFC_fmapFC #-}
+lhs_traverseFC_fmapFC :: SmallArrayF V Ctx3 -> Identity (SmallArrayF V Ctx3)
+lhs_traverseFC_fmapFC arr = traverseFC (Identity . twaddle) (fmapFC twiddle arr)
+
+{-# NOINLINE rhs_traverseFC_fmapFC #-}
+rhs_traverseFC_fmapFC :: SmallArrayF V Ctx3 -> Identity (SmallArrayF V Ctx3)
+rhs_traverseFC_fmapFC arr = traverseFC (Identity . twaddle . twiddle) arr
+
+-- Fusion rules: itraverseFC/fmapFC_
+
+{-# NOINLINE lhs_itraverseFC_fmapFC #-}
+lhs_itraverseFC_fmapFC :: SmallArrayF V Ctx3 -> Identity (SmallArrayF V Ctx3)
+lhs_itraverseFC_fmapFC arr = itraverseFC (\idx x -> Identity (itwiddle idx x)) (fmapFC twiddle arr)
+
+{-# NOINLINE rhs_itraverseFC_fmapFC #-}
+rhs_itraverseFC_fmapFC :: SmallArrayF V Ctx3 -> Identity (SmallArrayF V Ctx3)
+rhs_itraverseFC_fmapFC arr = itraverseFC (\idx -> Identity . itwiddle idx . twiddle) arr
+
+-- Fusion rules: itraverseFC/imapFC_
+
+{-# NOINLINE lhs_itraverseFC_imapFC #-}
+lhs_itraverseFC_imapFC :: SmallArrayF V Ctx3 -> Identity (SmallArrayF V Ctx3)
+lhs_itraverseFC_imapFC arr = itraverseFC (\idx x -> Identity (itwiddle idx x)) (imapFC itwaddle arr)
+
+{-# NOINLINE rhs_itraverseFC_imapFC #-}
+rhs_itraverseFC_imapFC :: SmallArrayF V Ctx3 -> Identity (SmallArrayF V Ctx3)
+rhs_itraverseFC_imapFC arr = itraverseFC (\idx -> Identity . itwiddle idx . itwaddle idx) arr
+
+-- Fusion rules: imapFC_/fmapFC_
+
+{-# NOINLINE lhs_imapFC_fmapFC #-}
+lhs_imapFC_fmapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_imapFC_fmapFC arr = imapFC itwiddle (fmapFC twiddle arr)
+
+{-# NOINLINE rhs_imapFC_fmapFC #-}
+rhs_imapFC_fmapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_imapFC_fmapFC arr = imapFC (\idx -> itwiddle idx . twiddle) arr
+
+-- Fusion rules: imapFC_/imapFC_
+
+{-# NOINLINE lhs_imapFC_imapFC #-}
+lhs_imapFC_imapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_imapFC_imapFC arr = imapFC itwiddle (imapFC itwaddle arr)
+
+{-# NOINLINE rhs_imapFC_imapFC #-}
+rhs_imapFC_imapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_imapFC_imapFC arr = imapFC (\idx -> itwiddle idx . itwaddle idx) arr
+
+-- Fusion rules: fmapFC_/imapFC_
+
+{-# NOINLINE lhs_fmapFC_imapFC #-}
+lhs_fmapFC_imapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_fmapFC_imapFC arr = fmapFC twaddle (imapFC itwaddle arr)
+
+{-# NOINLINE rhs_fmapFC_imapFC #-}
+rhs_fmapFC_imapFC :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_fmapFC_imapFC arr = imapFC (\idx -> twaddle . itwaddle idx) arr
+
+-- Specialization: generateA/Identity
+
+{-# NOINLINE lhs_generateA_Identity #-}
+lhs_generateA_Identity :: Ctx.Size Ctx3 -> (forall tp. Index Ctx3 tp -> Identity (V tp)) -> Identity (SmallArrayF V Ctx3)
+lhs_generateA_Identity sz fn = SAF.generateA sz fn
+
+{-# NOINLINE rhs_generateA_Identity #-}
+rhs_generateA_Identity :: Ctx.Size Ctx3 -> (forall tp. Index Ctx3 tp -> Identity (V tp)) -> Identity (SmallArrayF V Ctx3)
+rhs_generateA_Identity sz fn = Identity (SAF.generate sz (runIdentity . fn))
+
+-- Identity: fmapFC_/id
+
+{-# NOINLINE lhs_fmapFC_id #-}
+lhs_fmapFC_id :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_fmapFC_id arr = fmapFC (\x -> x) arr
+
+{-# NOINLINE rhs_fmapFC_id #-}
+rhs_fmapFC_id :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_fmapFC_id arr = arr
+
+-- Cancellation: fromAssignment/toAssignment
+
+{-# NOINLINE lhs_fromTo #-}
+lhs_fromTo :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_fromTo a = SAF.fromAssignment (SAF.toAssignment a)
+
+{-# NOINLINE rhs_fromTo #-}
+rhs_fromTo :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_fromTo a = a
+
+-- Cancellation: toAssignment/fromAssignment
+
+{-# NOINLINE lhs_toFrom #-}
+lhs_toFrom :: Ctx.Assignment V Ctx3 -> Ctx.Assignment V Ctx3
+lhs_toFrom a = SAF.toAssignment (SAF.fromAssignment a)
+
+{-# NOINLINE rhs_toFrom #-}
+rhs_toFrom :: Ctx.Assignment V Ctx3 -> Ctx.Assignment V Ctx3
+rhs_toFrom a = a
+
+-- Specialization: traverseFC/ST
+
+{-# NOINLINE lhs_traverseFC_ST #-}
+lhs_traverseFC_ST :: SmallArrayF V Ctx3 -> ST s (SmallArrayF V Ctx3)
+lhs_traverseFC_ST arr = traverseFC stTwiddle arr
+
+{-# NOINLINE rhs_traverseFC_ST #-}
+rhs_traverseFC_ST :: SmallArrayF V Ctx3 -> ST s (SmallArrayF V Ctx3)
+rhs_traverseFC_ST arr = SAF.traverseFCST stTwiddle arr
+
+-- Specialization: traverseFC/IO
+
+{-# NOINLINE lhs_traverseFC_IO #-}
+lhs_traverseFC_IO :: SmallArrayF V Ctx3 -> IO (SmallArrayF V Ctx3)
+lhs_traverseFC_IO arr = traverseFC ioTwiddle arr
+
+{-# NOINLINE rhs_traverseFC_IO #-}
+rhs_traverseFC_IO :: SmallArrayF V Ctx3 -> IO (SmallArrayF V Ctx3)
+rhs_traverseFC_IO arr = SAF.traverseFCIO ioTwiddle arr
+
+-- Specialization: itraverseFC/ST
+
+{-# NOINLINE lhs_itraverseFC_ST #-}
+lhs_itraverseFC_ST :: SmallArrayF V Ctx3 -> ST s (SmallArrayF V Ctx3)
+lhs_itraverseFC_ST arr = itraverseFC istTwiddle arr
+
+{-# NOINLINE rhs_itraverseFC_ST #-}
+rhs_itraverseFC_ST :: SmallArrayF V Ctx3 -> ST s (SmallArrayF V Ctx3)
+rhs_itraverseFC_ST arr = SAF.itraverseFCST istTwiddle arr
+
+-- Specialization: itraverseFC/IO
+
+{-# NOINLINE lhs_itraverseFC_IO #-}
+lhs_itraverseFC_IO :: SmallArrayF V Ctx3 -> IO (SmallArrayF V Ctx3)
+lhs_itraverseFC_IO arr = itraverseFC ioiTwiddle arr
+
+{-# NOINLINE rhs_itraverseFC_IO #-}
+rhs_itraverseFC_IO :: SmallArrayF V Ctx3 -> IO (SmallArrayF V Ctx3)
+rhs_itraverseFC_IO arr = SAF.itraverseFCIO ioiTwiddle arr
+
+-- Specialization: zipWithMFC/ST
+
+{-# NOINLINE lhs_zipWithMFC_ST #-}
+lhs_zipWithMFC_ST :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> ST s (SmallArrayF V Ctx3)
+lhs_zipWithMFC_ST a b = SAF.zipWithMFC stZipFn a b
+
+{-# NOINLINE rhs_zipWithMFC_ST #-}
+rhs_zipWithMFC_ST :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> ST s (SmallArrayF V Ctx3)
+rhs_zipWithMFC_ST a b = SAF.zipWithMFCST stZipFn a b
+
+-- Specialization: zipWithMFC/IO
+
+{-# NOINLINE lhs_zipWithMFC_IO #-}
+lhs_zipWithMFC_IO :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> IO (SmallArrayF V Ctx3)
+lhs_zipWithMFC_IO a b = SAF.zipWithMFC ioZipFn a b
+
+{-# NOINLINE rhs_zipWithMFC_IO #-}
+rhs_zipWithMFC_IO :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> IO (SmallArrayF V Ctx3)
+rhs_zipWithMFC_IO a b = SAF.zipWithMFCIO ioZipFn a b
+
+-- Cancellation: take/append
+
+{-# NOINLINE lhs_take_append #-}
+lhs_take_append :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_take_append a b = SAF.take (SAF.size a) (SAF.size b) (SAF.append a b)
+
+{-# NOINLINE rhs_take_append #-}
+rhs_take_append :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_take_append a _ = a
+
+-- Cancellation: drop/append
+
+{-# NOINLINE lhs_drop_append #-}
+lhs_drop_append :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+lhs_drop_append a b = SAF.drop (SAF.size a) (SAF.size b) (SAF.append a b)
+
+{-# NOINLINE rhs_drop_append #-}
+rhs_drop_append :: SmallArrayF V Ctx3 -> SmallArrayF V Ctx3 -> SmallArrayF V Ctx3
+rhs_drop_append _ b = b
+
+------------------------------------------------------------------------
+-- Test tree
+
+tests :: TT.TestTree
+tests = TT.testGroup "SmallArrayF RULES (inspection)"
+  [ $(inspectTest $ 'lhs_generateA_Identity ==~ 'rhs_generateA_Identity)
+  , $(inspectTest $ 'lhs_fmapFC_id ==~ 'rhs_fmapFC_id)
+  , $(inspectTest $ 'lhs_fmapFC_fmapFC ==~ 'rhs_fmapFC_fmapFC)
+  , $(inspectTest $ 'lhs_traverseFC_fmapFC ==~ 'rhs_traverseFC_fmapFC)
+  , $(inspectTest $ 'lhs_itraverseFC_fmapFC ==~ 'rhs_itraverseFC_fmapFC)
+  , $(inspectTest $ 'lhs_itraverseFC_imapFC ==~ 'rhs_itraverseFC_imapFC)
+  , $(inspectTest $ 'lhs_imapFC_fmapFC ==~ 'rhs_imapFC_fmapFC)
+  , $(inspectTest $ 'lhs_imapFC_imapFC ==~ 'rhs_imapFC_imapFC)
+  , $(inspectTest $ 'lhs_fmapFC_imapFC ==~ 'rhs_fmapFC_imapFC)
+  , $(inspectTest $ 'lhs_fromTo ==~ 'rhs_fromTo)
+  , $(inspectTest $ 'lhs_toFrom ==~ 'rhs_toFrom)
+  , $(inspectTest $ 'lhs_traverseFC_ST ==~ 'rhs_traverseFC_ST)
+  , $(inspectTest $ 'lhs_traverseFC_IO ==~ 'rhs_traverseFC_IO)
+  , $(inspectTest $ 'lhs_itraverseFC_ST ==~ 'rhs_itraverseFC_ST)
+  , $(inspectTest $ 'lhs_itraverseFC_IO ==~ 'rhs_itraverseFC_IO)
+  , $(inspectTest $ 'lhs_zipWithMFC_ST ==~ 'rhs_zipWithMFC_ST)
+  , $(inspectTest $ 'lhs_zipWithMFC_IO ==~ 'rhs_zipWithMFC_IO)
+  , $(inspectTest $ 'lhs_take_append ==~ 'rhs_take_append)
+  , $(inspectTest $ 'lhs_drop_append ==~ 'rhs_drop_append)
+  ]
+
+#else
+
+tests :: TT.TestTree
+tests = TT.testGroup "SmallArrayF RULES (inspection)" []
+
+#endif

--- a/test/Test/SmallArrayF/RulesCoverage.hs
+++ b/test/Test/SmallArrayF/RulesCoverage.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Meta-tests: asserts that every RULE defined in SmallArrayF.hs has
+-- a corresponding semantic correctness test and an inspection test.
+--
+-- This relies on each rule being in its own @{-# RULES "name" ... #-}@
+-- pragma (one rule per pragma) so parsing is trivial.
+
+module Test.SmallArrayF.RulesCoverage (tests) where
+
+import           Data.List (isInfixOf, sort, (\\))
+import qualified Test.Tasty as TT
+import qualified Test.Tasty.HUnit as TTH
+
+sourceFile :: FilePath
+sourceFile = "src/Data/Parameterized/SmallArrayF.hs"
+
+semanticsFile :: FilePath
+semanticsFile = "test/Test/SmallArrayF/RulesSemantics.hs"
+
+inspectionFile :: FilePath
+inspectionFile = "test/Test/SmallArrayF/Rules.hs"
+
+extractRuleNames :: String -> [String]
+extractRuleNames = concatMap extract . lines
+  where
+    extract l
+      | "{-# RULES \"" `isInfixOf` l = firstQuoted (snd (break (== '"') l))
+      | otherwise = []
+    firstQuoted ('"':rest) = [takeWhile (/= '"') rest]
+    firstQuoted _ = []
+
+extractTestNames :: String -> [String]
+extractTestNames = concatMap extract . lines
+  where
+    extract l
+      | "testPropertyNamed" `isInfixOf` l = firstQuoted (dropWhile (/= '"') l)
+      | "testCase" `isInfixOf` l = firstQuoted (dropWhile (/= '"') l)
+      | otherwise = []
+    firstQuoted ('"':rest) = [takeWhile (/= '"') rest]
+    firstQuoted _ = []
+
+-- Extract rule names referenced in inspection test section comments
+-- (lines like "-- Fusion rules: fmapFC_/fmapFC_" or
+-- "-- Specialization: traverseFC/ST").
+extractInspectedRules :: String -> [String]
+extractInspectedRules = concatMap extract . lines
+  where
+    extract l
+      | "-- " `isInfixOf` l && any (`isInfixOf` l) prefixes =
+          case dropWhile (/= ':') l of
+            (':':' ':rest) -> [takeWhile (\c -> c /= ' ' && c /= '\n') rest]
+            _ -> []
+      | otherwise = []
+    prefixes = ["Fusion rules:", "Specialization:", "Cancellation:", "Identity:"]
+
+tests :: TT.TestTree
+tests = TT.testGroup "SmallArrayF RULES (coverage)"
+  [ TTH.testCase "every RULE has a semantic test" $ do
+      src <- readFile sourceFile
+      sem <- readFile semanticsFile
+      let ruleNames = sort (extractRuleNames src)
+          testNames = sort (extractTestNames sem)
+          missing = ruleNames \\ testNames
+      TTH.assertBool
+        ("Rules without semantic tests: " ++ show missing)
+        (null missing)
+  , TTH.testCase "every RULE has an inspection test" $ do
+      src <- readFile sourceFile
+      insp <- readFile inspectionFile
+      let ruleNames = sort (extractRuleNames src)
+          inspected = sort (extractInspectedRules insp)
+          missing = ruleNames \\ inspected
+      TTH.assertBool
+        ("Rules without inspection test: " ++ show missing)
+        (null missing)
+  ]

--- a/test/Test/SmallArrayF/RulesSemantics.hs
+++ b/test/Test/SmallArrayF/RulesSemantics.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Semantic correctness tests for SmallArrayF RULES.
+--
+-- Each property verifies that the LHS and RHS of a rule produce the
+-- same result on random inputs.  The combinators are wrapped with
+-- NOINLINE to prevent GHC from applying the very rules we are
+-- testing -- we want to evaluate each side independently and compare.
+--
+-- These tests complement the inspection tests: inspection verifies
+-- the rule fires, these verify it preserves meaning.
+
+module Test.SmallArrayF.RulesSemantics (tests) where
+
+import           Control.Monad.ST (runST)
+import           Data.Functor.Identity (Identity(Identity, runIdentity))
+import           Data.Kind (Type)
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.Context (Index)
+import           Data.Parameterized.Classes (ShowF(showF))
+import           Data.Parameterized.Some
+import qualified Data.Parameterized.SmallArrayF as SAF
+import           Data.Parameterized.SmallArrayF (SmallArrayF)
+import           Data.Parameterized.TraversableFC
+import           Data.Parameterized.TraversableFC.WithIndex
+import           Hedgehog
+import qualified Hedgehog.Gen as HG
+import           Hedgehog.Range (linear)
+import qualified Test.Tasty as TT
+import           Test.Tasty.Hedgehog
+
+------------------------------------------------------------------------
+-- Payload: a simple uniform wrapper around Ordering
+
+newtype V (tp :: Type) = V Int
+  deriving (Show, Eq)
+
+instance ShowF V where
+  showF (V n) = show n
+
+------------------------------------------------------------------------
+-- Generator
+
+genSomeVList :: Gen [Some V]
+genSomeVList = HG.list (linear 1 12) (Some . V <$> HG.int (linear (-100) 100))
+
+mkArr :: [Some V] -> Some (SmallArrayF V)
+mkArr vals =
+  case go Ctx.empty vals of
+    Some a -> Some (SAF.fromAssignment a)
+  where
+    go :: Ctx.Assignment V ctx -> [Some V] -> Some (Ctx.Assignment V)
+    go acc []            = Some acc
+    go acc (Some x : xs) = go (Ctx.extend acc x) xs
+
+toList :: SmallArrayF V ctx -> [Int]
+toList = foldrFC (\(V n) r -> n : r) []
+
+------------------------------------------------------------------------
+-- NOINLINE combinators to prevent rule firing during semantics tests.
+
+-- Eta-expanded: GHC 9.0-9.2 can't unify the rank-N class methods with
+-- these monomorphic signatures when written pointfree.
+{-# NOINLINE myFmapFC #-}
+myFmapFC :: (forall tp. f tp -> g tp) -> SmallArrayF f ctx -> SmallArrayF g ctx
+myFmapFC h arr = fmapFC h arr
+
+{-# NOINLINE myImapFC #-}
+myImapFC :: (forall tp. Index ctx tp -> f tp -> g tp) -> SmallArrayF f ctx -> SmallArrayF g ctx
+myImapFC h arr = imapFC h arr
+
+{-# NOINLINE myTraverseFC #-}
+myTraverseFC :: Applicative m => (forall tp. f tp -> m (g tp)) -> SmallArrayF f ctx -> m (SmallArrayF g ctx)
+myTraverseFC h arr = traverseFC h arr
+
+{-# NOINLINE myItraverseFC #-}
+myItraverseFC :: Applicative m => (forall tp. Index ctx tp -> f tp -> m (g tp)) -> SmallArrayF f ctx -> m (SmallArrayF g ctx)
+myItraverseFC h arr = itraverseFC h arr
+
+{-# NOINLINE myZipWithMFC #-}
+myZipWithMFC :: Applicative m => (forall tp. f tp -> g tp -> m (h tp)) -> SmallArrayF f ctx -> SmallArrayF g ctx -> m (SmallArrayF h ctx)
+myZipWithMFC h a b = SAF.zipWithMFC h a b
+
+{-# NOINLINE myFromAssignment #-}
+myFromAssignment :: Ctx.Assignment f ctx -> SmallArrayF f ctx
+myFromAssignment = SAF.fromAssignment
+
+{-# NOINLINE myToAssignment #-}
+myToAssignment :: SmallArrayF f ctx -> Ctx.Assignment f ctx
+myToAssignment = SAF.toAssignment
+
+{-# NOINLINE myGenerateA #-}
+myGenerateA :: Applicative m => Ctx.Size ctx -> (forall tp. Index ctx tp -> m (f tp)) -> m (SmallArrayF f ctx)
+myGenerateA = SAF.generateA
+
+------------------------------------------------------------------------
+-- Element-level functions
+
+twiddle :: V tp -> V tp
+twiddle (V n) = V (n + 1)
+
+twaddle :: V tp -> V tp
+twaddle (V n) = V (n * 2)
+
+itwiddle :: Index ctx tp -> V tp -> V tp
+itwiddle idx (V n) = V (n + Ctx.indexVal idx)
+
+itwaddle :: Index ctx tp -> V tp -> V tp
+itwaddle idx (V n) = V (n * (1 + Ctx.indexVal idx))
+
+------------------------------------------------------------------------
+-- Properties
+
+prop_fmapFC_fmapFC :: Property
+prop_fmapFC_fmapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ myFmapFC twaddle (myFmapFC twiddle arr)
+      rhs = toList $ myFmapFC (twaddle . twiddle) arr
+  lhs === rhs
+
+prop_traverseFC_fmapFC :: Property
+prop_traverseFC_fmapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ runIdentity $ myTraverseFC (Identity . twaddle) (myFmapFC twiddle arr)
+      rhs = toList $ runIdentity $ myTraverseFC (Identity . twaddle . twiddle) arr
+  lhs === rhs
+
+prop_imapFC_fmapFC :: Property
+prop_imapFC_fmapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ myImapFC itwiddle (myFmapFC twiddle arr)
+      rhs = toList $ myImapFC (\idx -> itwiddle idx . twiddle) arr
+  lhs === rhs
+
+prop_imapFC_imapFC :: Property
+prop_imapFC_imapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ myImapFC itwiddle (myImapFC itwaddle arr)
+      rhs = toList $ myImapFC (\idx -> itwiddle idx . itwaddle idx) arr
+  lhs === rhs
+
+prop_fmapFC_imapFC :: Property
+prop_fmapFC_imapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ myFmapFC twaddle (myImapFC itwaddle arr)
+      rhs = toList $ myImapFC (\idx -> twaddle . itwaddle idx) arr
+  lhs === rhs
+
+prop_itraverseFC_fmapFC :: Property
+prop_itraverseFC_fmapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ runIdentity $ myItraverseFC (\idx x -> Identity (itwiddle idx x)) (myFmapFC twiddle arr)
+      rhs = toList $ runIdentity $ myItraverseFC (\idx -> Identity . itwiddle idx . twiddle) arr
+  lhs === rhs
+
+prop_itraverseFC_imapFC :: Property
+prop_itraverseFC_imapFC = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ runIdentity $ myItraverseFC (\idx x -> Identity (itwiddle idx x)) (myImapFC itwaddle arr)
+      rhs = toList $ runIdentity $ myItraverseFC (\idx -> Identity . itwiddle idx . itwaddle idx) arr
+  lhs === rhs
+
+prop_traverseFC_ST :: Property
+prop_traverseFC_ST = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ runST $ myTraverseFC (\(V n) -> pure (V (n + 1))) arr
+      rhs = toList $ runST $ SAF.traverseFCST (\(V n) -> pure (V (n + 1))) arr
+  lhs === rhs
+
+prop_traverseFC_IO :: Property
+prop_traverseFC_IO = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  lhs <- evalIO $ fmap toList $ myTraverseFC (\(V n) -> pure (V (n + 1))) arr
+  rhs <- evalIO $ fmap toList $ SAF.traverseFCIO (\(V n) -> pure (V (n + 1))) arr
+  lhs === rhs
+
+prop_itraverseFC_ST :: Property
+prop_itraverseFC_ST = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ runST $ myItraverseFC (\idx (V n) -> pure (V (n + Ctx.indexVal idx))) arr
+      rhs = toList $ runST $ SAF.itraverseFCST (\idx (V n) -> pure (V (n + Ctx.indexVal idx))) arr
+  lhs === rhs
+
+prop_itraverseFC_IO :: Property
+prop_itraverseFC_IO = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  lhs <- evalIO $ fmap toList $ myItraverseFC (\idx (V n) -> pure (V (n + Ctx.indexVal idx))) arr
+  rhs <- evalIO $ fmap toList $ SAF.itraverseFCIO (\idx (V n) -> pure (V (n + Ctx.indexVal idx))) arr
+  lhs === rhs
+
+prop_zipWithMFC_ST :: Property
+prop_zipWithMFC_ST = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ runST $ myZipWithMFC (\(V a) (V b) -> pure (V (a + b))) arr arr
+      rhs = toList $ runST $ SAF.zipWithMFCST (\(V a) (V b) -> pure (V (a + b))) arr arr
+  lhs === rhs
+
+prop_zipWithMFC_IO :: Property
+prop_zipWithMFC_IO = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  lhs <- evalIO $ fmap toList $ myZipWithMFC (\(V a) (V b) -> pure (V (a + b))) arr arr
+  rhs <- evalIO $ fmap toList $ SAF.zipWithMFCIO (\(V a) (V b) -> pure (V (a + b))) arr arr
+  lhs === rhs
+
+prop_fromTo :: Property
+prop_fromTo = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let lhs = toList $ myFromAssignment (myToAssignment arr)
+  lhs === toList arr
+
+prop_toFrom :: Property
+prop_toFrom = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  let asgn = myToAssignment arr
+      lhs  = myToAssignment (myFromAssignment asgn)
+  toListFC (\(V n) -> n) lhs === toListFC (\(V n) -> n) asgn
+
+prop_generateA_Identity :: Property
+prop_generateA_Identity = property $ do
+  vals <- forAll genSomeVList
+  Some (arr :: SmallArrayF V ctx) <- pure $ mkArr vals
+  let fn :: forall tp. Index ctx tp -> Identity (V tp)
+      fn idx = Identity (arr SAF.! idx)
+      lhs = runIdentity $ myGenerateA (SAF.size arr) fn
+      rhs = runIdentity $ Identity (SAF.generate (SAF.size arr) (runIdentity . fn))
+  toList lhs === toList rhs
+
+prop_fmapFC_id :: Property
+prop_fmapFC_id = property $ do
+  vals <- forAll genSomeVList
+  Some arr <- pure $ mkArr vals
+  toList (myFmapFC (\x -> x) arr) === toList arr
+
+prop_takeAppend :: Property
+prop_takeAppend = property $ do
+  xs <- forAll genSomeVList
+  ys <- forAll genSomeVList
+  Some a <- pure $ mkArr xs
+  Some b <- pure $ mkArr ys
+  let combined = SAF.append a b
+      lhs = toList $ SAF.take (SAF.size a) (SAF.size b) combined
+  lhs === toList a
+
+prop_dropAppend :: Property
+prop_dropAppend = property $ do
+  xs <- forAll genSomeVList
+  ys <- forAll genSomeVList
+  Some a <- pure $ mkArr xs
+  Some b <- pure $ mkArr ys
+  let combined = SAF.append a b
+      lhs = toList $ SAF.drop (SAF.size a) (SAF.size b) combined
+  lhs === toList b
+
+------------------------------------------------------------------------
+-- Test tree
+
+tests :: TT.TestTree
+tests = TT.testGroup "SmallArrayF RULES (semantics)"
+  [ testPropertyNamed "fmapFC_/fmapFC_" "prop_fmapFC_fmapFC" prop_fmapFC_fmapFC
+  , testPropertyNamed "traverseFC/fmapFC_" "prop_traverseFC_fmapFC" prop_traverseFC_fmapFC
+  , testPropertyNamed "imapFC_/fmapFC_" "prop_imapFC_fmapFC" prop_imapFC_fmapFC
+  , testPropertyNamed "imapFC_/imapFC_" "prop_imapFC_imapFC" prop_imapFC_imapFC
+  , testPropertyNamed "fmapFC_/imapFC_" "prop_fmapFC_imapFC" prop_fmapFC_imapFC
+  , testPropertyNamed "itraverseFC/fmapFC_" "prop_itraverseFC_fmapFC" prop_itraverseFC_fmapFC
+  , testPropertyNamed "itraverseFC/imapFC_" "prop_itraverseFC_imapFC" prop_itraverseFC_imapFC
+  , testPropertyNamed "traverseFC/ST" "prop_traverseFC_ST" prop_traverseFC_ST
+  , testPropertyNamed "traverseFC/IO" "prop_traverseFC_IO" prop_traverseFC_IO
+  , testPropertyNamed "itraverseFC/ST" "prop_itraverseFC_ST" prop_itraverseFC_ST
+  , testPropertyNamed "itraverseFC/IO" "prop_itraverseFC_IO" prop_itraverseFC_IO
+  , testPropertyNamed "zipWithMFC/ST" "prop_zipWithMFC_ST" prop_zipWithMFC_ST
+  , testPropertyNamed "zipWithMFC/IO" "prop_zipWithMFC_IO" prop_zipWithMFC_IO
+  , testPropertyNamed "fromAssignment/toAssignment" "prop_fromTo" prop_fromTo
+  , testPropertyNamed "toAssignment/fromAssignment" "prop_toFrom" prop_toFrom
+  , testPropertyNamed "generateA/Identity" "prop_generateA_Identity" prop_generateA_Identity
+  , testPropertyNamed "fmapFC_/id" "prop_fmapFC_id" prop_fmapFC_id
+  , testPropertyNamed "take/append" "prop_takeAppend" prop_takeAppend
+  , testPropertyNamed "drop/append" "prop_dropAppend" prop_dropAppend
+  ]

--- a/test/UnitTest.hs
+++ b/test/UnitTest.hs
@@ -7,6 +7,11 @@ import qualified Test.Fin
 import qualified Test.FinMap
 import qualified Test.List
 import qualified Test.NatRepr
+import qualified Test.SmallArrayF
+import qualified Test.SmallArrayF.Instances
+import qualified Test.SmallArrayF.Rules
+import qualified Test.SmallArrayF.RulesCoverage
+import qualified Test.SmallArrayF.RulesSemantics
 import qualified Test.Some
 import qualified Test.SymbolRepr
 import qualified Test.TH
@@ -29,6 +34,11 @@ tests = testGroup "ParameterizedUtils" <$> sequence
   , Test.Fin.finTests
   , Test.FinMap.finMapTests
   , Test.NatRepr.natTests
+  , Test.SmallArrayF.smallArrayFTests
+  , pure Test.SmallArrayF.Instances.tests
+  , pure Test.SmallArrayF.Rules.tests
+  , pure Test.SmallArrayF.RulesSemantics.tests
+  , pure Test.SmallArrayF.RulesCoverage.tests
   , Test.Some.someTests
   , Test.SymbolRepr.symbolTests
   , Test.TH.thTests


### PR DESCRIPTION
As described in the Haddock, this is about trading `Assignment`'s amortized O(1) extend for `SmallArrayF`'s O(1) indexing and compactness for small-array, write-once, read-often scenarios, of which we have many in What4, Crucible, and GREASE.

This is a lot of unsafe code, including unsafe coercions and trusted rewrite rules. The testing strategy is:

- Property tests
- Property tests for tyupeclass instances
- Property tests for rule correctness - comparing LHS vs RHS
- Inspection tests for rules - making sure they produce the right Core