### PR TITLE
`Data.Parameterized.Fin`: Add `Num` instance and related functions 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2
     with:
-      cache-key-prefix: v3
+      cache-key-prefix: v4
       # See doc/dev.md for development practices around warnings.
       #
       # See Note [Parallelism] in `haskell-ci.yml` for why `--ghc-options='-j'`

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,9 @@
 
 ## next
 
-* Add a `Hashable` instance for `Fin`.
+* Add `Hashable` and `Num` instances for `Fin`.
+* Add `mkFinModN`, `finFromNatModN`, `addFinModN`, `subFinModN`, `mulFinModN`,
+  and `negFinModN` to `Data.Parameterized.Fin`.
 * Add `modNat`, `modIsLeq`, and `withModLeq` to `Data.Parameterized.NatRepr`.
 
 ## 2.3.0.0 -- 2026-03-06

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## next
 
 * Add a `Hashable` instance for `Fin`.
+* Add `modNat`, `modIsLeq`, and `withModLeq` to `Data.Parameterized.NatRepr`.
 
 ## 2.3.0.0 -- 2026-03-06
 

--- a/src/Data/Parameterized/Fin.hs
+++ b/src/Data/Parameterized/Fin.hs
@@ -23,15 +23,21 @@ that naturally has a fixed size bound of @n@.
 module Data.Parameterized.Fin
   ( Fin
   , mkFin
+  , mkFinModN
   , buildFin
   , countFin
   , viewFin
+  , finFromNatModN
   , finToNat
   , embed
   , tryEmbed
   , minFin
   , incFin
   , fin0Absurd
+  , addFinModN
+  , subFinModN
+  , mulFinModN
+  , negFinModN
   ) where
 
 import Data.Hashable (Hashable(..))
@@ -39,6 +45,7 @@ import GHC.TypeNats (KnownNat)
 import Numeric.Natural (Natural)
 
 import Data.Parameterized.NatRepr
+import Data.Parameterized.Some (Some(..))
 
 -- | The type @'Fin' n@ has exactly @n@ inhabitants.
 data Fin n =
@@ -60,6 +67,37 @@ instance (1 <= n, KnownNat n) => Bounded (Fin n) where
     case minusPlusCancel (knownNat @n) (knownNat @1) of
       Refl -> Fin (decNat (knownNat @n))
 
+-- | Arithmetic is performed modulo @n@.
+instance (1 <= n, KnownNat n) => Num (Fin n) where
+  (+) = addFinModN (knownNat @n)
+  (-) = subFinModN (knownNat @n)
+  (*) = mulFinModN (knownNat @n)
+  negate = negFinModN (knownNat @n)
+
+  -- | We consider all Fin values to be non-negative. Therefore, this always
+  -- returns the input unchanged.
+  abs = id
+
+  -- | We consider all Fin values to be non-negative. Therefore, this always
+  -- returns either 'minFin' (i.e., zero) or @'mkFinModN' n (knownNat \@1)@
+  -- (i.e., one). Note that in the degenerate case of @'Fin' 1@, these values
+  -- will be equal to each other.
+  signum f
+    | f == minFin
+    = f
+    | otherwise
+    = mkFinModN (knownNat @n) (knownNat @1)
+
+  -- | Negative integers are negated, reduced modulo @n@, and then negated
+  -- again using 'negFinModN'.
+  fromInteger i
+    | i >= 0
+    = finFromNatModN n (fromInteger i)
+    | otherwise
+    = negFinModN n (finFromNatModN n (negate (fromInteger i)))
+    where
+      n = knownNat @n
+
 -- | Non-lawful instance, intended only for testing.
 instance Show (Fin n) where
   show i = "Fin " ++ show (finToNat i)
@@ -67,6 +105,11 @@ instance Show (Fin n) where
 mkFin :: forall i n. (i + 1 <= n) => NatRepr i -> Fin n
 mkFin = Fin
 {-# INLINE mkFin #-}
+
+-- | Construct a @'Fin' n@ value from the number @i@, where @i@ is reduced
+-- modulo @n@.
+mkFinModN :: (1 <= n) => NatRepr n -> NatRepr i -> Fin n
+mkFinModN n i = withModLeq i n Fin
 
 newtype Fin' n = Fin' { getFin' :: Fin (n + 1) }
 
@@ -95,6 +138,13 @@ countFin m f =
 
 viewFin ::  (forall i. (i + 1 <= n) => NatRepr i -> r) -> Fin n -> r
 viewFin f (Fin i) = f i
+
+-- | Construct a @'Fin' n@ value from a 'Natural' input, where the input is
+-- reduced modulo @n@.
+finFromNatModN :: forall n. (1 <= n) => NatRepr n -> Natural -> Fin n
+finFromNatModN n i
+  | Some i' <- mkNatRepr i
+  = mkFinModN n i'
 
 finToNat :: Fin n -> Natural
 finToNat (Fin i) = natValue i
@@ -132,3 +182,24 @@ fin0Absurd =
       case plusComm x (knownNat @1) of
         Refl ->
           case addIsLeqLeft1 @1 @o @0 LeqProof of {})
+
+-- | Add two @'Fin' n@ values and reduce the result modulo @n@.
+addFinModN :: (1 <= n) => NatRepr n -> Fin n -> Fin n -> Fin n
+addFinModN n (Fin x) (Fin y) = mkFinModN n (addNat x y)
+
+-- | Subtract two @'Fin' n@ values and reduce the result modulo @n@.
+subFinModN :: (1 <= n) => NatRepr n -> Fin n -> Fin n -> Fin n
+subFinModN n x y = addFinModN n x (negFinModN n y)
+
+-- | Multiply two @'Fin' n@ values and reduce the result modulo @n@.
+mulFinModN :: (1 <= n) => NatRepr n -> Fin n -> Fin n -> Fin n
+mulFinModN n (Fin x) (Fin y) = mkFinModN n (natMultiply x y)
+
+-- | Given a value @i :: 'Fin' n@ value, negate it. That is, if @i@ is zero,
+-- then return @i@ unchanged, and if @i@ is non-zero, then compute @n - i@.
+-- This is a negation in the sense that it is an additive inverse: adding @i@
+-- to its negation will yield 'minFin'.
+negFinModN :: forall n. (1 <= n) => NatRepr n -> Fin n -> Fin n
+negFinModN n (Fin (i :: NatRepr i))
+  | LeqProof <- addIsLeqLeft1 @i @1 @n LeqProof
+  = mkFinModN n (subNat n i)

--- a/src/Data/Parameterized/NatRepr.hs
+++ b/src/Data/Parameterized/NatRepr.hs
@@ -54,6 +54,7 @@ module Data.Parameterized.NatRepr
   , addNat
   , subNat
   , divNat
+  , modNat
   , halfNat
   , withDivModNat
   , natMultiply
@@ -108,6 +109,8 @@ module Data.Parameterized.NatRepr
   , addIsLeqLeft1
   , dblPosIsPos
   , leqMulMono
+  , modIsLeq
+  , withModLeq
     -- * Arithmetic proof
   , plusComm
   , plusAssoc
@@ -137,7 +140,7 @@ import Data.Type.Equality as Equality
 import Data.Void as Void
 import Numeric.Natural
 import GHC.TypeNats ( KnownNat, Nat, SomeNat(..)
-                    , type (+), type (-), type (*), type (<=)
+                    , type (+), type (-), type (*), type (<=), type Mod
                     , someNatVal )
 import Unsafe.Coerce
 
@@ -217,6 +220,9 @@ subNat (NatRepr m) (NatRepr n) = NatRepr (m-n)
 
 divNat :: (1 <= n) => NatRepr (m * n) -> NatRepr n -> NatRepr m
 divNat (NatRepr x) (NatRepr y) = NatRepr (div x y)
+
+modNat :: (1 <= n) => NatRepr m -> NatRepr n -> NatRepr (Mod m n)
+modNat (NatRepr x) (NatRepr y) = NatRepr (mod x y)
 
 withDivModNat :: forall n m a.
                  NatRepr n
@@ -523,6 +529,18 @@ withAddPrefixLeq n m = withLeqProof (addPrefixIsLeq n m)
 
 withAddLeq :: forall n m a. NatRepr n -> NatRepr m -> ((n <= n + m) => NatRepr (n + m) -> a) -> a
 withAddLeq n m f = withLeqProof (addIsLeq n m) (f (addNat n m))
+
+modIsLeq :: (1 <= m) => f n -> g m -> LeqProof (Mod n m + 1) m
+modIsLeq _ _ = unsafeCoerce (LeqProof @0 @0)
+{-# NOINLINE modIsLeq #-}
+
+withModLeq ::
+  (1 <= m) =>
+  NatRepr n ->
+  NatRepr m ->
+  ((Mod n m + 1 <= m) => NatRepr (Mod n m) -> a) ->
+  a
+withModLeq n m f = withLeqProof (modIsLeq n m) (f (modNat n m))
 
 natForEach' :: forall l h a
             . NatRepr l

--- a/test/Test/Fin.hs
+++ b/test/Test/Fin.hs
@@ -60,6 +60,98 @@ prop_count_false = property $
   do Some n <- forAll (genNatRepr 100)
      finToNat (countFin n (\_ _ -> False)) === 0
 
+prop_add_comm :: Property
+prop_add_comm = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     b <- forAll (genFin n10)
+     (a + b) === (b + a)
+
+prop_add_identity :: Property
+prop_add_identity = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     (mkFin (knownNat @0) + a) === a
+
+prop_add_inverse :: Property
+prop_add_inverse = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     (a + negate a) === mkFin (knownNat @0)
+
+prop_add_assoc :: Property
+prop_add_assoc = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     b <- forAll (genFin n10)
+     c <- forAll (genFin n10)
+     a + (b + c) === (a + b) + c
+
+prop_add_negate_sub :: Property
+prop_add_negate_sub = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     b <- forAll (genFin n10)
+     (a + negate b) === (a - b)
+
+prop_sub_anticomm :: Property
+prop_sub_anticomm = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     b <- forAll (genFin n10)
+     (a - b) === negate (b - a)
+
+prop_mul_comm :: Property
+prop_mul_comm = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     b <- forAll (genFin n10)
+     (a * b) === (b * a)
+
+prop_mul_identity :: Property
+prop_mul_identity = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     (mkFin (knownNat @1) * a) === a
+
+prop_mul_assoc :: Property
+prop_mul_assoc = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     b <- forAll (genFin n10)
+     c <- forAll (genFin n10)
+     a * (b * c) === (a * b) * c
+
+prop_mul_annihilate :: Property
+prop_mul_annihilate = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     (mkFin (knownNat @0) * a) === mkFin (knownNat @0)
+
+prop_neg_inv :: Property
+prop_neg_inv = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     negate (negate a) === a
+
+prop_abs_idem :: Property
+prop_abs_idem = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     abs (abs a) === abs a
+
+prop_signum_idem :: Property
+prop_signum_idem = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     signum (signum a) === signum a
+
+prop_abs_signum :: Property
+prop_abs_signum = property $
+  do let n10 = knownNat @10
+     a <- forAll (genFin n10)
+     (abs a * signum a) === a
+
 finTests :: IO TestTree
 finTests =
   testGroup "Fin" <$>
@@ -80,6 +172,21 @@ finTests =
 
       , testPropertyNamed "count-true" "prop_count_true" prop_count_true
       , testPropertyNamed "count-false" "prop_count_false" prop_count_false
+
+      , testPropertyNamed "add-comm" "prop_add_comm" prop_add_comm
+      , testPropertyNamed "add-identity" "prop_add_identity" prop_add_identity
+      , testPropertyNamed "add-inverse" "prop_add_inverse" prop_add_inverse
+      , testPropertyNamed "add-assoc" "prop_add_assoc" prop_add_assoc
+      , testPropertyNamed "add-negate-sub" "prop_add_negate_sub" prop_add_negate_sub
+      , testPropertyNamed "sub-anticomm" "prop_sub_anticomm" prop_sub_anticomm
+      , testPropertyNamed "mul-comm" "prop_mul_comm" prop_mul_comm
+      , testPropertyNamed "mul-identity" "prop_mul_identity" prop_mul_identity
+      , testPropertyNamed "mul-annihilate" "prop_mul_annihilate" prop_mul_annihilate
+      , testPropertyNamed "mul-assoc" "prop_mul_assoc" prop_mul_assoc
+      , testPropertyNamed "neg-inv" "prop_neg_inv" prop_neg_inv
+      , testPropertyNamed "abs-idem" "prop_abs_idem" prop_abs_idem
+      , testPropertyNamed "signum-idem" "prop_signum_idem" prop_signum_idem
+      , testPropertyNamed "abs-signum" "prop_abs_signum" prop_abs_signum
 
 #if __GLASGOW_HASKELL__ >= 806
       , testCase "Eq-Fin-laws-1" $


### PR DESCRIPTION
Fixes https://github.com/GaloisInc/parameterized-utils/issues/231.

In order to define these, I also needed to add a `withModLeq` helper function, which I put in a separate commit.