### PR TITLE
Tweak `Fin`'s `Show` instance to parenthesize output when needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2
     with:
-      cache-key-prefix: v4
+      cache-key-prefix: v5
       # See doc/dev.md for development practices around warnings.
       #
       # See Note [Parallelism] in `haskell-ci.yml` for why `--ghc-options='-j'`

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 * Add `mkFinModN`, `finFromNatModN`, `addFinModN`, `subFinModN`, `mulFinModN`,
   and `negFinModN` to `Data.Parameterized.Fin`.
 * Add `modNat`, `modIsLeq`, and `withModLeq` to `Data.Parameterized.NatRepr`.
+* Change the `Show` instance for `Fin` such that calling `showsPrec p` will
+  parenthesize the output if `p` is sufficiently large.
 
 ## 2.3.0.0 -- 2026-03-06
 

--- a/src/Data/Parameterized/Fin.hs
+++ b/src/Data/Parameterized/Fin.hs
@@ -98,9 +98,10 @@ instance (1 <= n, KnownNat n) => Num (Fin n) where
     where
       n = knownNat @n
 
--- | Non-lawful instance, intended only for testing.
+-- Equivalent to what a derived Show instance would be, except that we
+-- intentionally do not print out the (non-exported) _getFin field name.
 instance Show (Fin n) where
-  show i = "Fin " ++ show (finToNat i)
+  showsPrec p i = showParen (p >= 11) $ showString "Fin " . shows (finToNat i)
 
 mkFin :: forall i n. (i + 1 <= n) => NatRepr i -> Fin n
 mkFin = Fin

--- a/test/Test/Fin.hs
+++ b/test/Test/Fin.hs
@@ -164,6 +164,14 @@ finTests =
           assertBool
             "minBound <= maxBound (2)"
             ((minBound :: Fin 2) <= (minBound :: Fin 2))
+      , testCase "show (minFin @1) == \"Fin 0\"" $
+          assertBool
+            "show (minFin @1) == \"Fin 0\""
+            (show (minFin @1) == "Fin 0")
+      , testCase "show (Just (minFin @1)) == \"Just (Fin 0)\"" $
+          assertBool
+            "show (Just (minFin @1)) == \"Just (Fin 0)\""
+            (show (Just (minFin @1)) == "Just (Fin 0)")
 
       , testPropertyNamed
           "Eq equality implies hash equality"


### PR DESCRIPTION
Fixes #236.